### PR TITLE
Add useRestForTeamRepos to more safely complete sdk 2 transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ## 1.0.0 - 2021-07-09
 
+### Added
+
+- new optional config variable `useRestForTeamRepos` that can is sometimes
+  needed to get around a GitHub error when fetching team repos via GraphQL.
+
 ### Changed
 
 - octokit packages to be dependencies instead of peer dependencies.

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,7 +91,13 @@ export class APIClient {
     }
     const teams: OrgTeamQueryResponse[] = await this.accountClient.getTeams();
     const allTeamMembers: OrgTeamMemberQueryResponse[] = await this.accountClient.getTeamMembers();
-    const allTeamRepos: OrgTeamRepoQueryResponse[] = await this.accountClient.getTeamRepositories();
+    // Check 'useRestForTeamRepos' config variable as a hack to allow large github
+    // accounts to bypass a Github error. Please delete this code once that error is fixed.
+    const allTeamRepos: OrgTeamRepoQueryResponse[] = this.config
+      .useRestForTeamRepos
+      ? await this.accountClient.getTeamReposWithRest()
+      : await this.accountClient.getTeamRepositories();
+
     for (const team of teams) {
       team.members = allTeamMembers.filter(
         (member) => member.teams === team.id,

--- a/src/client/OrganizationAccountClient.ts
+++ b/src/client/OrganizationAccountClient.ts
@@ -229,63 +229,70 @@ export default class OrganizationAccountClient {
             'Organization query for team repositories failed',
           )
         ) {
-          if (!this.teams) {
-            throw new Error(
-              'Do not attempt to call REST version of getTeamRepositories without first calling getTeams!',
-            );
-          }
-
-          for (const team of this.teams) {
-            try {
-              const teamRepositories = await this.v3.paginate(
-                'GET /orgs/{org}/teams/{team_slug}/repos', // https://docs.github.com/en/rest/reference/teams#list-team-repositories
-                {
-                  org: this.login,
-                  team_slug: team.slug,
-                  per_page: 100,
-                },
-                (response) => {
-                  this.logger.info(
-                    {
-                      teamRepositoriesPageLength: response.data.length,
-                      team: sha(team.slug),
-                    },
-                    'Fetched page of team repositories',
-                  );
-                  this.v3RateLimitConsumed++;
-                  return response.data;
-                },
-              );
-
-              return teamRepositories.map((tr) => {
-                let permission: TeamRepositoryPermission;
-                if (tr.permissions?.admin) {
-                  permission = TeamRepositoryPermission.Admin;
-                } else if (tr.permissions?.push) {
-                  permission = TeamRepositoryPermission.Write;
-                } else {
-                  permission = TeamRepositoryPermission.Read;
-                }
-
-                return {
-                  id: tr.node_id,
-                  teams: team.id,
-                  url: tr.url,
-                  name: tr.name,
-                  nameWithOwner: tr.full_name,
-                  permission,
-                  isPrivate: tr.private,
-                  isArchived: tr.archived,
-                  createdAt: tr.created_at as string,
-                  updatedAt: tr.updated_at as string,
-                };
-              });
-            } catch (err) {
-              throw new IntegrationError(err);
-            }
-          }
+          return await this.getTeamReposWithRest();
         }
       } //end of catch and REST call
+    }
+
+    return this.teamRepositories || [];
+  }
+
+  // This is a hack to allow large github accounts to bypass a Github error. Please delete this code once that error is fixed.
+  async getTeamReposWithRest(): Promise<OrgTeamRepoQueryResponse[]> {
+    if (!this.teams) {
+      throw new Error(
+        'Do not attempt to call REST version of getTeamRepositories without first calling getTeams!',
+      );
+    }
+
+    for (const team of this.teams) {
+      try {
+        const teamRepositories = await this.v3.paginate(
+          'GET /orgs/{org}/teams/{team_slug}/repos', // https://docs.github.com/en/rest/reference/teams#list-team-repositories
+          {
+            org: this.login,
+            team_slug: team.slug,
+            per_page: 100,
+          },
+          (response) => {
+            this.logger.info(
+              {
+                teamRepositoriesPageLength: response.data.length,
+                team: sha(team.slug),
+              },
+              'Fetched page of team repositories',
+            );
+            this.v3RateLimitConsumed++;
+            return response.data;
+          },
+        );
+
+        return teamRepositories.map((tr) => {
+          let permission: TeamRepositoryPermission;
+          if (tr.permissions?.admin) {
+            permission = TeamRepositoryPermission.Admin;
+          } else if (tr.permissions?.push) {
+            permission = TeamRepositoryPermission.Write;
+          } else {
+            permission = TeamRepositoryPermission.Read;
+          }
+
+          return {
+            id: tr.node_id,
+            teams: team.id,
+            url: tr.url,
+            name: tr.name,
+            nameWithOwner: tr.full_name,
+            permission,
+            isPrivate: tr.private,
+            isArchived: tr.archived,
+            createdAt: tr.created_at as string,
+            updatedAt: tr.updated_at as string,
+          };
+        });
+      } catch (err) {
+        throw new IntegrationError(err);
+      }
     }
 
     return this.teamRepositories || [];

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,9 @@ export const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   analyzeCommitApproval: {
     type: 'boolean',
   },
+  useRestForTeamRepos: {
+    type: 'boolean',
+  },
 };
 
 /**
@@ -79,6 +82,14 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
   analyzeCommitApproval: boolean;
 
   /**
+   * This is a hack to allow this integration to complete for organizations with lots of Team Repo data.
+   * For unusually large Github accounts, GraphQL has been known to throw errors on TeamRepos calls.
+   * This is a known bug from the Github side, but the exact triggering details are currently unknown.
+   * This hack should get removed once we are confident we can do so without affecting customers.
+   */
+  useRestForTeamRepos: boolean;
+
+  /**
    * Optional. Login is usually derived from a call to the API,
    * but if that fails or is not available, processing can proceed
    * if this var is specified.
@@ -113,6 +124,11 @@ export function sanitizeConfig(config: IntegrationConfig) {
       );
     }
   }
+
+  // Set this as a default as it is a hack that isn't in the regular integration configuration.
+  config.useRestForTeamRepos = config.useRestForTeamRepos
+    ? config.useRestForTeamRepos
+    : false;
 
   if (
     !config.githubAppId ||

--- a/test/config.ts
+++ b/test/config.ts
@@ -20,4 +20,5 @@ export const integrationConfig: IntegrationConfig = {
     Number(process.env.INSTALLATION_ID) || DEFAULT_INSTALLATION_ID,
   analyzeCommitApproval: true,
   githubAppDefaultLogin: 'something', //can be set manually in tests
-};
+  // useRestForTeamRepos: false
+} as IntegrationConfig; // casting config instead of setting useRestForTeamRepos to imitate configs already in production


### PR DESCRIPTION
This should be removed directly after the initial transition as this is not a good pattern.