### PR TITLE
make sure the commit exists prior to comparing it

### DIFF
--- a/src/approval/collectCommitsForPR.ts
+++ b/src/approval/collectCommitsForPR.ts
@@ -36,6 +36,7 @@ export default async function collectCommitsForPR(
     .filter(
       (approval) =>
         hasTeamApprovals(approval, teamMemberLogins) &&
+        approvalHasValidCommit(approval) &&
         hasPeerApprovals(approval, commits),
     );
 
@@ -98,6 +99,10 @@ function hasTeamApprovals(approval: Approval, teamMembers: string[]) {
     teamMembers.includes(approver),
   );
   return teamApprovers.length > 0;
+}
+
+function approvalHasValidCommit(approval: Approval) {
+  return !!approval.commit?.length;
 }
 
 function fromUnknownAuthor(

--- a/src/approval/getCommitsToDestination.test.ts
+++ b/src/approval/getCommitsToDestination.test.ts
@@ -1,0 +1,37 @@
+import { PullsListCommitsResponseItem } from '../types';
+import getCommitsToDestination from './getCommitsToDestination';
+
+describe('getCommitsToDestination', () => {
+  test('should be able to handle pull requests with an empty destination commit', () => {
+    const commits: PullsListCommitsResponseItem[] = [
+      {
+        url: 'url',
+        sha: 'sha',
+        node_id: 'node_id',
+        html_url: 'html_url',
+        comments_url: 'comments_url',
+        author: {} as PullsListCommitsResponseItem['author'],
+        committer: {} as PullsListCommitsResponseItem['committer'],
+        parents: [
+          {
+            sha: 'sha',
+            url: 'url',
+          },
+        ],
+        commit: {
+          url: 'url',
+          author: {},
+          committer: {},
+          message: '',
+          comment_count: 0,
+          tree: {
+            sha: 'sha',
+            url: 'url',
+          },
+        },
+      },
+    ];
+    const destination = (undefined as unknown) as string;
+    expect(getCommitsToDestination(commits, destination)).toHaveLength(0);
+  });
+});

--- a/src/approval/getCommitsToDestination.ts
+++ b/src/approval/getCommitsToDestination.ts
@@ -3,7 +3,7 @@ import { PullsListCommitsResponseItem } from '../types';
 function commitMatches(commit: string, match: string): boolean {
   // using the length of the proposed match allows for matching shas of
   // different length, so that abcdefghij12345678 matches abcdefghij
-  return commit.slice(0, match.length) === match;
+  return !!match?.length && commit.slice(0, match.length) === match;
 }
 
 export default function getCommitsToDestination(


### PR DESCRIPTION
Fix error for NextRoll
```
TypeError: Cannot read property 'length' of undefined
at commitMatches (/opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/approval/getCommitsToDestination.js:6:34)
at /opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/approval/getCommitsToDestination.js:9:60
at Array.findIndex (<anonymous>)
at Object.getCommitsToDestination [as default] (/opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/approval/getCommitsToDestination.js:9:38)
at hasPeerApprovals (/opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/approval/collectCommitsForPR.js:37:64)
at /opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/approval/collectCommitsForPR.js:15:9
at Array.filter (<anonymous>)
at Object.collectCommitsForPR [as default] (/opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/approval/collectCommitsForPR.js:14:10)
at async p_map_1.default.concurrency (/opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/client/OrganizationAccountClient.js:222:97)
```