### PR TITLE
Ints 70 cursors fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed broken cursor handling for nested objects, which made some larger
+  GraphQL queries never terminate.
+
 ## 1.8.9 - 2021-11-19
 
 ### Changed

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -454,12 +454,12 @@ export class GitHubGraphQLClient {
         }
       }
 
-      queryCursors = mapResponseCursorsForQuery(pageCursors, queryCursors);
-
       this.logger.info(
         { rateLimit, queryCursors, pageCursors, resourceNums },
         `Rate limit response for iteration`,
       );
+
+      queryCursors = mapResponseCursorsForQuery(pageCursors, queryCursors);
 
       hasMoreResources = Object.values(pageCursors).some((c) => c.hasNextPage);
     } while (hasMoreResources);

--- a/src/client/GraphQLClient/queries.ts
+++ b/src/client/GraphQLClient/queries.ts
@@ -16,8 +16,8 @@
  *
  */
 
-export const MAX_REQUESTS_NUM = 100;
-export const LIMITED_REQUESTS_NUM = 25; //this is sometimes used to avoid errors
+export const MAX_REQUESTS_NUM = 1;
+export const LIMITED_REQUESTS_NUM = 1; //this is sometimes used to avoid errors
 
 export const ACCOUNT_QUERY_STRING = `query ($login: String!) {
     organization(login: $login) {

--- a/src/client/GraphQLClient/queries.ts
+++ b/src/client/GraphQLClient/queries.ts
@@ -16,8 +16,8 @@
  *
  */
 
-export const MAX_REQUESTS_NUM = 1;
-export const LIMITED_REQUESTS_NUM = 1; //this is sometimes used to avoid errors
+export const MAX_REQUESTS_NUM = 100;
+export const LIMITED_REQUESTS_NUM = 25; //this is sometimes used to avoid errors
 
 export const ACCOUNT_QUERY_STRING = `query ($login: String!) {
     organization(login: $login) {

--- a/src/client/GraphQLClient/response.test.ts
+++ b/src/client/GraphQLClient/response.test.ts
@@ -5,12 +5,12 @@ describe('mapResponseCursorsForQuery', () => {
     const cursors = {
       teams: {
         self: 'teamsSelfCursor',
-        children: {}
-      }
+        children: {},
+      },
     };
 
     expect(mapResponseCursorsForQuery(cursors, {})).toEqual({
-      teams: 'teamsSelfCursor'
+      teams: 'teamsSelfCursor',
     });
   });
 
@@ -22,19 +22,20 @@ describe('mapResponseCursorsForQuery', () => {
           teamMembers: [
             {
               self: 'teamMembersSelfCursorOne',
-              children: {}
+              children: {},
             },
             {
               self: 'teamMembersSelfCursorTwo',
-              children: {}
-            }
-          ]
-        }
-      }
+              children: {},
+            },
+          ],
+        },
+      },
     };
 
     expect(mapResponseCursorsForQuery(cursors, {})).toEqual({
-      teamMembers: 'teamMembersSelfCursorOne'
+      teamMembers: 'teamMembersSelfCursorOne',
+      teams: 'teamsSelfCursor',
     });
   });
 
@@ -46,31 +47,32 @@ describe('mapResponseCursorsForQuery', () => {
           teamMembers: [
             {
               self: 'teamMembersSelfCursorOne',
-              children: {}
+              children: {},
             },
             {
               self: 'teamMembersSelfCursorTwo',
-              children: {}
-            }
+              children: {},
+            },
           ],
           teamRepositories: [
             {
               self: 'teamRepositoriesSelfCursor',
-              children: {}
-            }
-          ]
-        }
+              children: {},
+            },
+          ],
+        },
       },
       repositories: {
         self: 'repositoriesSelfCursor',
-        children: {}
-      }
+        children: {},
+      },
     };
 
     expect(mapResponseCursorsForQuery(cursors, {})).toEqual({
       teamMembers: 'teamMembersSelfCursorOne',
       teamRepositories: 'teamRepositoriesSelfCursor',
-      repositories: 'repositoriesSelfCursor'
+      repositories: 'repositoriesSelfCursor',
+      teams: 'teamsSelfCursor',
     });
   });
 
@@ -86,18 +88,20 @@ describe('mapResponseCursorsForQuery', () => {
                 teamMemberRepositories: [
                   {
                     self: 'teamMemberRepositoriesSelfCursor',
-                    children: {}
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
+                    children: {},
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
     };
 
     expect(mapResponseCursorsForQuery(cursors, {})).toEqual({
-      teamMemberRepositories: 'teamMemberRepositoriesSelfCursor'
+      teamMemberRepositories: 'teamMemberRepositoriesSelfCursor',
+      teamMembers: 'teamMembersSelfCursorOne',
+      teams: 'teamsSelfCursor',
     });
   });
 
@@ -109,20 +113,20 @@ describe('mapResponseCursorsForQuery', () => {
           teamMembers: [
             {
               self: 'teamMembersSelfCursorOne',
-              children: {}
-            }
-          ]
-        }
-      }
+              children: {},
+            },
+          ],
+        },
+      },
     };
 
     expect(
       mapResponseCursorsForQuery(cursors, {
-        teams: 'teamsPreviousCursor'
-      })
+        teams: 'teamsPreviousCursor',
+      }),
     ).toEqual({
       teams: 'teamsPreviousCursor',
-      teamMembers: 'teamMembersSelfCursorOne'
+      teamMembers: 'teamMembersSelfCursorOne',
     });
   });
 
@@ -130,16 +134,16 @@ describe('mapResponseCursorsForQuery', () => {
     const cursors = {
       teams: {
         self: 'teamsSelfCursor',
-        children: {}
-      }
+        children: {},
+      },
     };
 
     expect(
       mapResponseCursorsForQuery(cursors, {
-        teams: 'teamsPreviousCursor'
-      })
+        teams: 'teamsPreviousCursor',
+      }),
     ).toEqual({
-      teams: 'teamsSelfCursor'
+      teams: 'teamsSelfCursor',
     });
   });
 });

--- a/src/client/GraphQLClient/response.ts
+++ b/src/client/GraphQLClient/response.ts
@@ -6,7 +6,7 @@ import {
 } from './types';
 
 export function mapResponseCursorsForQuery(
-  cursors: ResourceMap<CursorHierarchy>,
+  pageCursors: ResourceMap<CursorHierarchy>,
   queryCursors: ResourceMap<string>,
 ): ResourceMap<string> {
   function cursorsFromHierarchy(
@@ -40,7 +40,7 @@ export function mapResponseCursorsForQuery(
   }
 
   let flatCursors: ResourceMap<string> = {};
-  for (const [resource, cursorHierarchy] of Object.entries(cursors)) {
+  for (const [resource, cursorHierarchy] of Object.entries(pageCursors)) {
     flatCursors = {
       ...flatCursors,
       ...cursorsFromHierarchy(cursorHierarchy, resource, queryCursors),

--- a/src/client/GraphQLClient/response.ts
+++ b/src/client/GraphQLClient/response.ts
@@ -31,6 +31,10 @@ export function mapResponseCursorsForQuery(
 
       if (queryCursors[key]) {
         cursors[key] = queryCursors[key];
+      } else {
+        if (hierarchy.self) {
+          cursors[key] = hierarchy.self;
+        }
       }
     } else if (hierarchy.self) {
       cursors[key] = hierarchy.self;


### PR DESCRIPTION
Hi guys,

The problem was that when we had nested objects that were large enough for GraphQL to need multiple API calls, the cursors were resetting and starting over.

The recursive cursor logic for nested objects is tough to analyze with absolute certainty, but I found the problem by changing the pagination limits in `queries.ts` to `1`.  This PR fixes the problem under those conditions and produces the correct snapshots for my test account. 

Naturally, for the real code, I had to change the query limits back, but I can say for certain that the changes in this PR are confined to what is already broken, so it won't make things any worse, and it does seem to solve the problem.

