### PR TITLE
Updating retry timeout to 1 hr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Changed GraphQL timeout 1 hour so it doesn't interfere with GraphQL sleep for
+  rate limit
+
 ## 1.8.12 - 2021-11-26
 
 ### Added

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -627,7 +627,7 @@ export class GitHubGraphQLClient {
     return await retry(queryWithRateLimitCatch, {
       maxAttempts: 3,
       delay: 30_000, // 30 seconds to start
-      timeout: 120_000, // 2 minute timeout. Github sometimes leaves us high-and-dry
+      timeout: 60_000 * 60, // 1 hour timeout. Cut this back to 2 min once sleepIfApproachingRateLimit is moved outside of this retry
       factor: 2, //exponential backoff factor. with 30 sec start and 3 attempts, longest wait is 2 min (total 3.5 min)
       handleError(err: any, attemptContext: AttemptContext) {
         /* retry will keep trying to the limits of retryOptions


### PR DESCRIPTION
Per discussion, updating 1 hr to avoid conflict with rate limit sleep function