### PR TITLE
INTS-113 & INTS-114 - Only ingest relationships if key has not already been ingested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- `github_team_has_user`, `github_user_manages_team`, and
+  `github_repo_allows_team` relationships will not be made if a relationship
+  with the same key has already been ingested in the same integration run.
+
 ## 1.8.13 - 2021-11-29
 
 ### Fixed

--- a/src/steps/teamRepos.ts
+++ b/src/steps/teamRepos.ts
@@ -34,10 +34,24 @@ export async function fetchTeamRepos({
         ) {
           const repoTeamRelationship = createRepoAllowsTeamRelationship(
             teamRepo.id,
-            teamRepo.teams,
+            teamEntity._key,
             teamRepo.permission,
           );
-          await jobState.addRelationship(repoTeamRelationship);
+          if (jobState.hasKey(repoTeamRelationship._key)) {
+            logger.warn(
+              {
+                teamId: teamEntity.id,
+                teamKey: teamEntity._key,
+                teamName: teamEntity.name,
+                teamRepoTeamKey: teamRepo.teams,
+                teamRepoId: teamRepo.id,
+                relationshipKey: repoTeamRelationship._key,
+              },
+              'Repo-team relationship was already ingested: Skipping.',
+            );
+          } else {
+            await jobState.addRelationship(repoTeamRelationship);
+          }
         } else {
           logger.warn(
             { repoId: teamRepo.id, teamId: teamRepo.teams },


### PR DESCRIPTION
I'm going to monitor the logs after deployment to see why we are getting duplicates.