### PR TITLE
Order team-repos and team-members api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Order to team-repos and team-members graphQL queries to ensure the correct
+  team is selected.
+
 ### Changed
 
 - Moved GraphQL sleep for rate limit outside of retry functions, and restored

--- a/src/client/GraphQLClient/queries.ts
+++ b/src/client/GraphQLClient/queries.ts
@@ -425,7 +425,7 @@ export const SINGLE_REPO_COLLABORATORS_QUERY_STRING = `query ($repoName: String!
 export const SINGLE_TEAM_REPOS_QUERY_STRING = `query ($login: String!, $slug: String!, $teamRepositories: String) {
   organization(login: $login) {
     id
-    teams(first: 1, query: $slug) {
+    teams(first: 1, query: $slug, orderBy: {field: NAME, direction: ASC}) {
     edges {
       node {
         id
@@ -454,7 +454,7 @@ endCursor
 export const SINGLE_TEAM_MEMBERS_QUERY_STRING = `query ($login: String!, $slug: String, $members: String) {
   organization(login: $login) {
       id
-      teams(first: 1, query: $slug) {
+      teams(first: 1, query: $slug, orderBy: {field: NAME, direction: ASC}) {
       edges {
         node {
           id


### PR DESCRIPTION
After running these queries locally, I noticed that searching for the "Integrations" team, would return "Integrations", "Integrations Admin", and "Integrations Contractors" teams. In order to ensure that we only return the team that we explicitly searched for, ordering by the name in ascending order and taking the first one will work.

There might be more that can be done with this. There are already logs that can be used to monitor if this change works. For reference, if we see see these logs go away
```
fields @timestamp, msg
| filter msg like 'relationship was already ingested: Skipping.'
```