### PR TITLE
Support for private repo commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to
 
 ### Added
 
-- `github_user` property `active` added, a boolean which is always true in the
-  case of GitHub Users, to conform with new SDK standards for User entities
+- Added `github_user` property `active` added, a boolean which is always true in
+  the case of GitHub Users, to conform with new SDK standards for User entities
+- Added support for the "Contents" scope in "Repository permissions", which
+  enables ingestion of private repo PR commits.
 
 ### 1.8.18 2021-1-04
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,3 +120,23 @@ Also note that enabled Pull Request scope for the app grants access to
 public-repo Pull Requests, but not private repo ones. The Issues scope grants
 access to private-repo Pull Requests, as well as all Issues on public and
 private repos.
+
+Also note that private-repo commits cannot be fetched without the Repo Contents
+scope, even if private-repo PRs can be fetched. Therefore, there are two
+possible GraphQL queries (with or without requesting commits) for private-repo
+PRs, depending on whether Repo Contents scope is enabled.
+
+## Scope enabled in the GitHub App
+
+Users of the GitHub App do not have fine-grain control over the App permissions.
+They simply install the App, and it gets all the permissions that the App has
+requested.
+
+However, users might install the App, and then additional permissions requests
+are added to the App later. In that case, the user is given a notification with
+the option to accept the new permissions. If they ignore that notification, the
+App keeps working with the existing permissions.
+
+In this way, it is possible for different installations of the App to be
+operating under different permission levels, and so development must take this
+into consideration.

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -54,6 +54,7 @@ read-only permissions to support ingestion of
 - Metadata: Read-only
 - Pull requests: Read-only
 - Issues: Read-only (enables both Issues and private-repo PRs)
+- Contents: Read-only (enables analyzing commits for private-repo PRs)
 - [Secrets](#secrets-caveat): Read-only
 
 #### Organization Permissions

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,6 +53,7 @@ export class APIClient {
     repoSecrets: boolean;
     repoEnvironments: boolean;
     repoIssues: boolean;
+    repoContents: boolean;
   };
   constructor(
     readonly config: IntegrationConfig,
@@ -310,6 +311,7 @@ export class APIClient {
         repo,
         lastSuccessfulExecution,
         iteratee,
+        this.scopes.repoContents,
       );
     logger.info(
       { rateLimitConsumed },
@@ -435,6 +437,7 @@ export class APIClient {
         repoSecrets: false,
         repoEnvironments: false,
         repoIssues: false,
+        repoContents: false,
       };
     }
     this.logger.info({ perms }, 'Permissions received with token');
@@ -506,7 +509,7 @@ export class APIClient {
       this.scopes.repoEnvironments = true;
     }
 
-    //ingesting repo issues requires scope issues:read
+    //ingesting repo issues or PRs from private repos requires scope issues:read
     if (!(perms.issues === 'read' || perms.issues === 'write')) {
       this.scopes.repoIssues = false;
       this.logger.info(
@@ -516,6 +519,18 @@ export class APIClient {
     } else {
       this.scopes.repoIssues = true;
     }
+
+    //ingesting private repo commits requires scope contents:read
+    if (!(perms.contents === 'read' || perms.contents === 'write')) {
+      this.scopes.repoContents = false;
+      this.logger.info(
+        {},
+        "Token does not have 'contents' scope. Private repo commits cannot be ingested.",
+      );
+    } else {
+      this.scopes.repoContents = true;
+    }
+
     //scopes check done
   }
 }

--- a/src/client/OrganizationAccountClient.ts
+++ b/src/client/OrganizationAccountClient.ts
@@ -283,6 +283,7 @@ export default class OrganizationAccountClient {
     repo: RepoEntity,
     lastExecutionTime: string, //expect Date.toISOString format
     iteratee: ResourceIteratee<PullRequest>,
+    privateRepoContentsAllowed: boolean,
   ): Promise<QueryResponse> {
     if (!this.authorizedForPullRequests) {
       this.logger.info('Account not authorized for ingesting pull requests.');
@@ -290,9 +291,10 @@ export default class OrganizationAccountClient {
     }
     lastExecutionTime = this.sanitizeLastExecutionTime(lastExecutionTime);
 
-    const prGraphQLQueryString = repo.public
-      ? PUBLIC_REPO_PULL_REQUESTS_QUERY_STRING
-      : PRIVATE_REPO_PULL_REQUESTS_QUERY_STRING;
+    const prGraphQLQueryString =
+      repo.public || privateRepoContentsAllowed
+        ? PUBLIC_REPO_PULL_REQUESTS_QUERY_STRING
+        : PRIVATE_REPO_PULL_REQUESTS_QUERY_STRING;
     const issuesSearchQuery = `is:pr repo:${repo.fullName} updated:>=${lastExecutionTime}`;
     return await this.v4.iteratePullRequests(
       prGraphQLQueryString,


### PR DESCRIPTION
This code supports ingestion of private-repo commits in PRs, if the "Contents" scope (under "Repository Permissions") is turned on in the App.

If that scope if not turned on (in the App, or for a given customer because they don't accept the permission change), then the integration will continue to use the modified query for private repos that does not request commits.

Therefore this code is safe to deploy whether or not the App permissions are modified.