### PR TITLE
Added concurrency to collabs and team-repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Added logging of token scopes for troubleshooting purposes
 - Updated documentation with notes on GitHub App scope details
+- Concurrency added to `fetch-collaborators` and `fetch-team-repos` to improve
+  integration speed
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/request": "^5.6.1",
     "@octokit/rest": "^18.11.4",
-    "graphql.js": "^0.6.7"
+    "graphql.js": "^0.6.7",
+    "p-queue": "^6.6.2"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^8.1.2"

--- a/src/steps/teamRepos.ts
+++ b/src/steps/teamRepos.ts
@@ -13,6 +13,7 @@ import {
   GITHUB_REPO_TEAM_RELATIONSHIP_TYPE,
 } from '../constants';
 import { TeamEntity } from '../types';
+import PQueue from 'p-queue';
 
 export async function fetchTeamRepos({
   instance,
@@ -22,43 +23,48 @@ export async function fetchTeamRepos({
   const config = instance.config;
   const apiClient = createAPIClient(config, logger);
 
+  const iteratorQueue = new PQueue({ concurrency: 3 });
+
   await jobState.iterateEntities(
     { _type: GITHUB_TEAM_ENTITY_TYPE },
     async (teamEntity: TeamEntity) => {
-      await apiClient.iterateTeamRepos(teamEntity, async (teamRepo) => {
-        //teamRepo.id is the repo id
-        //teamRepo.teams is the team id
-        if (
-          (await jobState.hasKey(teamRepo.id)) &&
-          (await jobState.hasKey(teamRepo.teams))
-        ) {
-          const repoTeamRelationship = createRepoAllowsTeamRelationship(
-            teamRepo.id,
-            teamEntity._key,
-            teamRepo.permission,
-          );
-          if (jobState.hasKey(repoTeamRelationship._key)) {
-            logger.warn(
-              {
-                teamId: teamEntity.id,
-                teamKey: teamEntity._key,
-                teamName: teamEntity.name,
-                teamRepoTeamKey: teamRepo.teams,
-                teamRepoId: teamRepo.id,
-                relationshipKey: repoTeamRelationship._key,
-              },
-              'Repo-team relationship was already ingested: Skipping.',
-            );
-          } else {
-            await jobState.addRelationship(repoTeamRelationship);
-          }
-        } else {
-          logger.warn(
-            { repoId: teamRepo.id, teamId: teamRepo.teams },
-            `Could not build relationship between team and repo.`,
-          );
-        }
-      });
+      await iteratorQueue.add(
+        async () =>
+          await apiClient.iterateTeamRepos(teamEntity, async (teamRepo) => {
+            //teamRepo.id is the repo id
+            //teamRepo.teams is the team id
+            if (
+              (await jobState.hasKey(teamRepo.id)) &&
+              (await jobState.hasKey(teamRepo.teams))
+            ) {
+              const repoTeamRelationship = createRepoAllowsTeamRelationship(
+                teamRepo.id,
+                teamEntity._key,
+                teamRepo.permission,
+              );
+              if (jobState.hasKey(repoTeamRelationship._key)) {
+                logger.warn(
+                  {
+                    teamId: teamEntity.id,
+                    teamKey: teamEntity._key,
+                    teamName: teamEntity.name,
+                    teamRepoTeamKey: teamRepo.teams,
+                    teamRepoId: teamRepo.id,
+                    relationshipKey: repoTeamRelationship._key,
+                  },
+                  'Repo-team relationship was already ingested: Skipping.',
+                );
+              } else {
+                await jobState.addRelationship(repoTeamRelationship);
+              }
+            } else {
+              logger.warn(
+                { repoId: teamRepo.id, teamId: teamRepo.teams },
+                `Could not build relationship between team and repo.`,
+              );
+            }
+          }),
+      );
     },
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4598,7 +4598,7 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-queue@^6.3.0:
+p-queue@^6.3.0, p-queue@^6.6.2:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
   integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==


### PR DESCRIPTION
Here is some concurrency for the longer GitHub integration steps, `fetch-team-repos` and `fetch-collaborators`. It works well on my test account, but with so little data, I'm not sure if the speed gains I'm seeing are meaningful (10 seconds instead of 14 seconds). 

Can anyone run it against jupiterone-dev and see if the speed improvement is substantial? And also if there are any gotchas running it against that larger data set?