### PR TITLE
Fix OrganizationQuery.ts to handle when rateLimit is not included

### DIFF
--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -104,7 +104,7 @@ export class GitHubGraphQLClient {
   }
 
   private collectRateLimitStatus(results: RateLimitStepSummary) {
-    if (results.limit && results.remaining && results.resetAt) {
+    if (results?.limit && results?.remaining && results?.resetAt) {
       this.rateLimitStatus = {
         limit: results.limit,
         remaining: results.remaining,

--- a/src/client/GraphQLClient/issueQueries/IssuesQuery.test.ts
+++ b/src/client/GraphQLClient/issueQueries/IssuesQuery.test.ts
@@ -21,7 +21,7 @@ describe('IssuesQuery', () => {
       );
 
       // Assert
-      expect(result.totalCost).toBe(6);
+      expect(result.totalCost).toBe(3);
       expect(iteratee).toHaveBeenCalledTimes(3);
       expect(iteratee.mock.calls[0][0]).toMatchSnapshot();
       expect(iteratee.mock.calls[1][0]).toMatchSnapshot();

--- a/src/client/GraphQLClient/issueQueries/__snapshots__/IssuesQuery.test.ts.snap
+++ b/src/client/GraphQLClient/issueQueries/__snapshots__/IssuesQuery.test.ts.snap
@@ -195,9 +195,5 @@ Object {
     "maxInnerLimit": 100,
     "maxSearchLimit": 25,
   },
-  "rateLimit": Object {
-    "cost": 5,
-    "remaining": 4983,
-  },
 }
 `;

--- a/src/client/GraphQLClient/issueQueries/testResponses.ts
+++ b/src/client/GraphQLClient/issueQueries/testResponses.ts
@@ -83,10 +83,6 @@ const issuesResponses = [
         hasNextPage: true,
       },
     },
-    rateLimit: {
-      cost: 5,
-      remaining: 4983,
-    },
   },
   // Send page
   {
@@ -137,7 +133,7 @@ const issuesResponses = [
       },
     },
     rateLimit: {
-      cost: 1,
+      cost: 3,
       remaining: 4983,
     },
   },

--- a/src/client/GraphQLClient/organizationQueries/OrganizationQuery.test.ts
+++ b/src/client/GraphQLClient/organizationQueries/OrganizationQuery.test.ts
@@ -35,4 +35,32 @@ describe('OrganizationQuery', () => {
     expect(result.organization).toEqual(response.organization);
     expect(executor.mock.calls[0][0]).toMatchSnapshot();
   });
+
+  test('#fetchOrganization without rateLimit', async () => {
+    const response = {
+      organization: {
+        id: 'O_kgDOBfl5ZQ',
+        login: 'j1-ingest',
+        name: 'j1-ingest',
+        createdAt: '2022-02-22T19:40:36Z',
+        updatedAt: '2022-03-23T20:28:45Z',
+        description: 'This is a test Org for J1 Ingestion',
+        email: 'test@test.com',
+        databaseId: 100235621,
+        isVerified: false,
+        location: 'United States of America',
+        websiteUrl: null,
+        url: 'https://github.com/j1-ingest',
+      },
+    };
+    const executor = jest.fn().mockResolvedValueOnce(response);
+
+    const result = await OrganizationQuery.fetchOrganization(
+      'j1-test',
+      executor,
+    );
+
+    expect(result.rateLimit).toEqual({ totalCost: 0 });
+    expect(result.organization).toEqual(response.organization);
+  });
 });

--- a/src/client/GraphQLClient/organizationQueries/OrganizationQuery.ts
+++ b/src/client/GraphQLClient/organizationQueries/OrganizationQuery.ts
@@ -45,7 +45,7 @@ const processResponseData = (responseData): OrganizationResults => {
   return {
     rateLimit: {
       ...rateLimit,
-      totalCost: rateLimit.cost,
+      totalCost: rateLimit?.cost ?? 0,
     },
     organization,
   };

--- a/src/client/OrganizationAccountClient.ts
+++ b/src/client/OrganizationAccountClient.ts
@@ -79,6 +79,11 @@ export default class OrganizationAccountClient {
 
     this.authorizedForPullRequests = true;
     this.v3RateLimitConsumed = 0;
+
+    this.logger.info(
+      { login: options.login, baseUrl: options.baseUrl },
+      'Constructing Organization Account client',
+    );
   }
 
   /**


### PR DESCRIPTION
- Fix OrganizationQuery.ts to handle when rateLimit is not included in response
   - Possible for GitHub Enterprise server configuration
- Added test without rateLimit in response
- Removed rateLimit from IssuesQuery.test.ts to verify functionality.