### PR TITLE
INT 3534 move to octokit graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,6 @@
     "@jupiterone/integration-sdk-core": "^8.12.1",
     "@jupiterone/integration-sdk-dev-tools": "^8.12.1",
     "@jupiterone/integration-sdk-testing": "^8.12.1",
-    "@octokit/auth-app": "^3.6.0",
-    "@octokit/core": "^3.5.1",
-    "@octokit/plugin-retry": "^3.0.9",
-    "@octokit/plugin-throttling": "^3.5.2",
-    "@octokit/rest": "^18.11.4",
     "@types/lodash.omit": "^4.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "dependencies": {
     "@octokit/auth-app": "^3.6.0",
     "@octokit/core": "^3.5.1",
+    "@octokit/graphql": "^4.8.0",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/request": "^5.6.1",
-    "@octokit/rest": "^18.11.4",
-    "graphql.js": "^0.6.8"
+    "@octokit/rest": "^18.11.4"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^8.12.1"

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "dependencies": {
     "@octokit/auth-app": "^3.6.0",
-    "@octokit/core": "^3.5.1",
+    "@octokit/core": "^3.6.0",
     "@octokit/graphql": "^4.8.0",
     "@octokit/plugin-retry": "^3.0.9",
-    "@octokit/plugin-throttling": "^3.5.2",
-    "@octokit/request": "^5.6.1",
-    "@octokit/rest": "^18.11.4"
+    "@octokit/plugin-throttling": "^3.6.2",
+    "@octokit/request": "^5.6.3",
+    "@octokit/rest": "^18.12.0"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^8.12.1"

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,9 +63,15 @@ export class APIClient {
     this.restApiUrl = config.githubApiBaseUrl.includes('api.github.com')
       ? config.githubApiBaseUrl
       : `${config.githubApiBaseUrl}/api/v3`;
+    // More info on baseUrl here: https://github.com/octokit/graphql.js/#use-with-github-enterprise
     this.graphqlUrl = config.githubApiBaseUrl.includes('api.github.com')
-      ? `${config.githubApiBaseUrl}/graphql`
-      : `${config.githubApiBaseUrl}/api/graphql`;
+      ? config.githubApiBaseUrl
+      : `${config.githubApiBaseUrl}/api`;
+
+    this.logger.debug(
+      { graphqlBaseUrl: this.graphqlUrl },
+      'GraphQL client base URL.',
+    );
   }
 
   public async verifyAuthentication(): Promise<void> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,7 +91,7 @@ export class APIClient {
     const { rateLimit, organization } =
       await this.accountClient.fetchOrganization();
 
-    this.logger.info(
+    this.logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Organization.',
     );
@@ -113,7 +113,7 @@ export class APIClient {
 
     const rateLimit = await this.accountClient.iterateOrgMembers(iteratee);
 
-    this.logger.info(
+    this.logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Org Members.',
     );
@@ -133,7 +133,7 @@ export class APIClient {
 
     const rateLimit = await this.accountClient.iterateTeams(iteratee);
 
-    this.logger.info(
+    this.logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Team Repositories.',
     );
@@ -158,7 +158,7 @@ export class APIClient {
       iteratee,
     );
 
-    this.logger.info(
+    this.logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Team Repositories.',
     );
@@ -182,7 +182,7 @@ export class APIClient {
       iteratee,
     );
 
-    this.logger.info(
+    this.logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Team Members.',
     );
@@ -331,7 +331,7 @@ export class APIClient {
       await this.setupAccountClient();
     }
     const rateLimit = await this.accountClient.iterateOrgRepositories(iteratee);
-    this.logger.info(
+    this.logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Org Repositories.',
     );
@@ -359,7 +359,7 @@ export class APIClient {
       lastSuccessfulExecution,
       iteratee,
     );
-    logger.info(
+    logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Pull Requests.',
     );
@@ -384,7 +384,7 @@ export class APIClient {
       iteratee,
     );
 
-    this.logger.info(
+    this.logger.debug(
       { rateLimit },
       'Rate limit consumed while fetching Issues.',
     );
@@ -411,7 +411,7 @@ export class APIClient {
         lastSuccessfulExecution,
         iteratee,
       );
-      this.logger.info(
+      this.logger.debug(
         { rateLimit },
         'Rate limit consumed while fetching Issues.',
       );

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -1,4 +1,4 @@
-import { graphql as ocktokitGraphQl } from '@octokit/graphql';
+import { graphql as octokitGraphQl } from '@octokit/graphql';
 
 import {
   IntegrationLogger,
@@ -90,11 +90,11 @@ export class GitHubGraphQLClient {
     authClient: Octokit,
   ) {
     this.graphqlUrl = graphqlUrl;
-    this.graph = ocktokitGraphQl.defaults({
+    this.graph = octokitGraphQl.defaults({
       baseUrl: this.graphqlUrl,
       headers: {
         'User-Agent': 'jupiterone-graph-github',
-        authorization: `token ${token}`,
+        Authorization: `token ${token}`,
       },
     });
     this.tokenExpires = tokenExpires;
@@ -131,10 +131,10 @@ export class GitHubGraphQLClient {
         token: string;
         expiresAt: string;
       };
-      this.graph = ocktokitGraphQl.defaults({
+      this.graph = octokitGraphQl.defaults({
         headers: {
           'User-Agent': 'jupiterone-graph-github',
-          authorization: `token ${token}`,
+          Authorization: `token ${token}`,
         },
       });
       this.tokenExpires = parseTimePropertyValue(expiresAt) || 0;

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -1,4 +1,4 @@
-import graphql, { GraphQLClient } from 'graphql.js';
+import { graphql as ocktokitGraphQl } from '@octokit/graphql';
 
 import {
   IntegrationLogger,
@@ -9,7 +9,6 @@ import { retry } from '@lifeomic/attempt';
 import { Octokit } from '@octokit/rest';
 
 import { ResourceIteratee } from '../../client';
-import fragments from './fragments';
 
 import {
   Collaborator,
@@ -39,6 +38,7 @@ import {
   handleNotFoundErrors,
   retryErrorHandle,
 } from './errorHandlers';
+import { graphql } from '@octokit/graphql/dist-types/types';
 
 const FIVE_MINUTES_IN_MILLIS = 300000;
 
@@ -71,7 +71,7 @@ export class GitHubGraphQLClient {
    *    ...
    *  ]
    */
-  private graph: GraphQLClient;
+  private graph: graphql;
 
   private readonly logger: IntegrationLogger;
   private authClient: Octokit;
@@ -90,14 +90,13 @@ export class GitHubGraphQLClient {
     authClient: Octokit,
   ) {
     this.graphqlUrl = graphqlUrl;
-    this.graph = graphql(this.graphqlUrl, {
+    this.graph = ocktokitGraphQl.defaults({
+      baseUrl: this.graphqlUrl,
       headers: {
         'User-Agent': 'jupiterone-graph-github',
-        Authorization: `token ${token}`,
+        authorization: `token ${token}`,
       },
-      asJSON: true,
     });
-    this.graph.fragment(fragments);
     this.tokenExpires = tokenExpires;
     this.logger = logger;
     this.authClient = authClient;
@@ -132,14 +131,12 @@ export class GitHubGraphQLClient {
         token: string;
         expiresAt: string;
       };
-      this.graph = graphql(this.graphqlUrl, {
+      this.graph = ocktokitGraphQl.defaults({
         headers: {
           'User-Agent': 'jupiterone-graph-github',
-          Authorization: `token ${token}`,
+          authorization: `token ${token}`,
         },
-        asJSON: true,
       });
-      this.graph.fragment(fragments);
       this.tokenExpires = parseTimePropertyValue(expiresAt) || 0;
     } catch (err) {
       this.logger.error(err);
@@ -371,7 +368,7 @@ export class GitHubGraphQLClient {
           { queryString, queryVariables, timeoutRetryAttempt },
           'Attempting GraphQL request',
         );
-        return await this.graph(queryString)(queryVariables);
+        return await this.graph(queryString, queryVariables);
       } catch (err) {
         logger.debug(
           { queryString, queryVariables, timeoutRetryAttempt, err },

--- a/src/client/GraphQLClient/collaboratorQueries/RepoCollaboratorsQuery.ts
+++ b/src/client/GraphQLClient/collaboratorQueries/RepoCollaboratorsQuery.ts
@@ -9,6 +9,7 @@ import {
 import { MAX_REQUESTS_LIMIT } from '../paginate';
 import paginate from '../paginate';
 import utils from '../utils';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   collaborators: CursorState;
@@ -42,7 +43,7 @@ const buildQuery: BuildQuery<QueryParams, QueryState> = (
           }
         }
       }
-      ...rateLimit
+      ...${fragments.rateLimit}
     }`;
 
   return {

--- a/src/client/GraphQLClient/collaboratorQueries/__snapshots__/RepoCollaborators.test.ts.snap
+++ b/src/client/GraphQLClient/collaboratorQueries/__snapshots__/RepoCollaborators.test.ts.snap
@@ -51,7 +51,14 @@ Object {
           }
         }
       }
-      ...rateLimit
+      ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }",
   "queryVariables": Object {
     "login": "J1-Test",
@@ -82,7 +89,14 @@ Object {
           }
         }
       }
-      ...rateLimit
+      ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }",
   "queryVariables": Object {
     "collaboratorCursor": "more2come==",

--- a/src/client/GraphQLClient/fragments.ts
+++ b/src/client/GraphQLClient/fragments.ts
@@ -120,7 +120,10 @@ export default {
       oid
     }
     author {
-      ...teamMemberFields # this used to be ...userFields
+      ...on User {
+          name
+          login
+        }
     }
     state
     submittedAt
@@ -130,7 +133,10 @@ export default {
   privateRepoPRReviewFields: `on PullRequestReview {
     id
     author {
-      ...teamMemberFields # this used to be ...userFields
+      ...on User {
+          name
+          login
+        }
     }
     state
     submittedAt
@@ -140,7 +146,10 @@ export default {
   pullRequestFields: `on PullRequest {
     additions
     author {
-      ...teamMemberFields # this used to be ...userFields
+      ...on User {
+        name
+        login
+      }
     }
     authorAssociation
     baseRefName
@@ -258,7 +267,10 @@ export default {
     id
     activeLockReason
     author {
-      ...teamMemberFields
+      ...on User {
+        name
+        login
+      }
     }
     authorAssociation
     body

--- a/src/client/GraphQLClient/issueQueries/IssuesQuery.ts
+++ b/src/client/GraphQLClient/issueQueries/IssuesQuery.ts
@@ -9,6 +9,7 @@ import {
 import { ExecutableQuery } from '../CreateQueryExecutor';
 import paginate, { MAX_REQUESTS_LIMIT, MAX_SEARCH_LIMIT } from '../paginate';
 import utils from '../utils';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   issues: CursorState;
@@ -49,7 +50,7 @@ const buildQuery: BuildQuery<QueryParams, QueryState> = (
           issueCount
           edges {
             node {
-            ...issueFields
+            ... ${fragments.issueFields}
             
             ... on Issue {
                 assignees(first: $maxInnerLimit) {
@@ -85,7 +86,7 @@ const buildQuery: BuildQuery<QueryParams, QueryState> = (
             hasNextPage
           }
         }
-        ...rateLimit
+        ...${fragments.rateLimit}
     }`;
 
   return {

--- a/src/client/GraphQLClient/issueQueries/__snapshots__/IssuesQuery.test.ts.snap
+++ b/src/client/GraphQLClient/issueQueries/__snapshots__/IssuesQuery.test.ts.snap
@@ -87,7 +87,43 @@ Object {
           issueCount
           edges {
             node {
-            ...issueFields
+            ... on Issue {
+    id
+    activeLockReason
+    author {
+      ...on User {
+        name
+        login
+      }
+    }
+    authorAssociation
+    body
+    # bodyHTML
+    # bodyResourcePath
+    bodyText
+    bodyUrl
+    closed # boolean 
+    closedAt
+    # comments # probably a child object if we want these
+    createdAt
+    createdViaEmail # boolean
+    databaseId
+    isPinned # boolean
+    lastEditedAt
+    locked # boolean
+    # milestone # a Milestone object, could put the fields in-line like author
+    number
+    # participants # Participants objects
+    # projectCards # ProjectCardConnection!
+    publishedAt
+    # reactionGroups # : [ReactionGroup!]
+    resourcePath
+    state
+    title
+    titleHTML
+    updatedAt
+    url
+  }
             
             ... on Issue {
                 assignees(first: $maxInnerLimit) {
@@ -123,7 +159,14 @@ Object {
             hasNextPage
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }",
   "queryVariables": Object {
     "issueQuery": "is:issue repo:J1-Test/happy-sunshine updated:>=2011-10-05T14:48:00.000Z",
@@ -151,7 +194,43 @@ Object {
           issueCount
           edges {
             node {
-            ...issueFields
+            ... on Issue {
+    id
+    activeLockReason
+    author {
+      ...on User {
+        name
+        login
+      }
+    }
+    authorAssociation
+    body
+    # bodyHTML
+    # bodyResourcePath
+    bodyText
+    bodyUrl
+    closed # boolean 
+    closedAt
+    # comments # probably a child object if we want these
+    createdAt
+    createdViaEmail # boolean
+    databaseId
+    isPinned # boolean
+    lastEditedAt
+    locked # boolean
+    # milestone # a Milestone object, could put the fields in-line like author
+    number
+    # participants # Participants objects
+    # projectCards # ProjectCardConnection!
+    publishedAt
+    # reactionGroups # : [ReactionGroup!]
+    resourcePath
+    state
+    title
+    titleHTML
+    updatedAt
+    url
+  }
             
             ... on Issue {
                 assignees(first: $maxInnerLimit) {
@@ -187,7 +266,14 @@ Object {
             hasNextPage
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }",
   "queryVariables": Object {
     "issueQuery": "is:issue repo:J1-Test/happy-sunshine updated:>=2011-10-05T14:48:00.000Z",

--- a/src/client/GraphQLClient/memberQueries/OrgMembersQuery.ts
+++ b/src/client/GraphQLClient/memberQueries/OrgMembersQuery.ts
@@ -9,6 +9,7 @@ import {
 } from '../types';
 import paginate from '../paginate';
 import utils from '../utils';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   members: CursorState;
@@ -33,9 +34,9 @@ const buildQuery: BuildQuery<string, QueryState> = (
           edges {
             node {
               id
-              ...userFields
+              ...${fragments.userFields}
             }
-            ...userEdgeFields
+            ...${fragments.userEdgeFields}
           }
           pageInfo {
             endCursor
@@ -43,7 +44,7 @@ const buildQuery: BuildQuery<string, QueryState> = (
           }
         }
       }
-      ...rateLimit
+      ...${fragments.rateLimit}
     }`;
 
   return {

--- a/src/client/GraphQLClient/memberQueries/TeamMembersQuery.ts
+++ b/src/client/GraphQLClient/memberQueries/TeamMembersQuery.ts
@@ -9,6 +9,7 @@ import {
 import { ExecutableQuery } from '../CreateQueryExecutor';
 import paginate from '../paginate';
 import utils from '../utils';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   members: CursorState;
@@ -35,9 +36,9 @@ const buildQuery: BuildQuery<QueryParams, QueryState> = (
             edges {
               node {
                 id
-              ...teamMemberFields
+                ...${fragments.teamMemberFields}
               }
-            ...teamMemberEdgeFields
+              ...${fragments.teamMemberEdgeFields}
             }
             pageInfo {
               endCursor
@@ -46,7 +47,7 @@ const buildQuery: BuildQuery<QueryParams, QueryState> = (
           }
         }
       }
-    ...rateLimit
+      ...${fragments.rateLimit}
     }`;
 
   return {

--- a/src/client/GraphQLClient/memberQueries/__snapshots__/OrgMembersQuery.test.ts.snap
+++ b/src/client/GraphQLClient/memberQueries/__snapshots__/OrgMembersQuery.test.ts.snap
@@ -9,9 +9,25 @@ exports[`OrgMemberQuery pagination of org members 1`] = `
           edges {
             node {
               id
-              ...userFields
+              ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
             }
-            ...userEdgeFields
+            ...on OrganizationMemberEdge {
+    hasTwoFactorEnabled
+    role
+  }
           }
           pageInfo {
             endCursor
@@ -19,6 +35,13 @@ exports[`OrgMemberQuery pagination of org members 1`] = `
           }
         }
       }
-      ...rateLimit
+      ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }"
 `;

--- a/src/client/GraphQLClient/memberQueries/__snapshots__/TeamMembersQuery.test.ts.snap
+++ b/src/client/GraphQLClient/memberQueries/__snapshots__/TeamMembersQuery.test.ts.snap
@@ -11,9 +11,14 @@ exports[`TeamMemberQuery pagination of team members 1`] = `
             edges {
               node {
                 id
-              ...teamMemberFields
+                ...on User {
+    name
+    login
+  }
               }
-            ...teamMemberEdgeFields
+              ...on TeamMemberEdge {
+    role
+  }
             }
             pageInfo {
               endCursor
@@ -22,6 +27,13 @@ exports[`TeamMemberQuery pagination of team members 1`] = `
           }
         }
       }
-    ...rateLimit
+      ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }"
 `;

--- a/src/client/GraphQLClient/organizationQueries/OrganizationQuery.ts
+++ b/src/client/GraphQLClient/organizationQueries/OrganizationQuery.ts
@@ -1,5 +1,6 @@
 import { ExecutableQuery, QueryExecutor } from '../CreateQueryExecutor';
 import { OrgQueryResponse, RateLimitStepSummary } from '../types';
+import fragments from '../fragments';
 
 const buildQuery = (login: string): ExecutableQuery => {
   const query = `
@@ -18,12 +19,7 @@ const buildQuery = (login: string): ExecutableQuery => {
         websiteUrl
         url
       }
-      rateLimit {
-        limit
-        cost
-        remaining
-        resetAt
-      }
+      ...${fragments.rateLimit}
     }`;
 
   return {

--- a/src/client/GraphQLClient/organizationQueries/OrganizationQuery.ts
+++ b/src/client/GraphQLClient/organizationQueries/OrganizationQuery.ts
@@ -18,7 +18,12 @@ const buildQuery = (login: string): ExecutableQuery => {
         websiteUrl
         url
       }
-      ...rateLimit
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
     }`;
 
   return {

--- a/src/client/GraphQLClient/organizationQueries/__snapshots__/OrganizationQuery.test.ts.snap
+++ b/src/client/GraphQLClient/organizationQueries/__snapshots__/OrganizationQuery.test.ts.snap
@@ -18,7 +18,12 @@ Object {
         websiteUrl
         url
       }
-      ...rateLimit
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
     }",
   "queryVariables": Object {
     "login": "j1-test",

--- a/src/client/GraphQLClient/organizationQueries/__snapshots__/OrganizationQuery.test.ts.snap
+++ b/src/client/GraphQLClient/organizationQueries/__snapshots__/OrganizationQuery.test.ts.snap
@@ -18,12 +18,14 @@ Object {
         websiteUrl
         url
       }
-      rateLimit {
-        limit
-        cost
-        remaining
-        resetAt
-      }
+      ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }",
   "queryVariables": Object {
     "login": "j1-test",

--- a/src/client/GraphQLClient/pullRequestQueries/PullRequestsQuery.test.ts
+++ b/src/client/GraphQLClient/pullRequestQueries/PullRequestsQuery.test.ts
@@ -24,6 +24,18 @@ describe('PullRequestsQuery', () => {
       expect(executableQuery).toMatchSnapshot();
     });
 
+    test('first private query - no query state', () => {
+      // Act
+      const executableQuery = buildQuery({
+        fullName: 'J1-Test/musical-palm-tree',
+        public: false,
+        lastExecutionTime: '2011-10-05T14:48:00.000Z',
+      });
+
+      // Assert
+      expect(executableQuery).toMatchSnapshot();
+    });
+
     test('query with query state', () => {
       // Arrange
       const queryState = {

--- a/src/client/GraphQLClient/pullRequestQueries/PullRequestsQuery.ts
+++ b/src/client/GraphQLClient/pullRequestQueries/PullRequestsQuery.ts
@@ -87,126 +87,70 @@ export const buildQuery: BuildQuery<QueryParams, QueryState> = (
 };
 
 const pullRequestFields = (isPublicRepo) => {
-  if (isPublicRepo) {
-    return `...on PullRequest {
-      additions
-      author {
-        ...${fragments.teamMemberFields}
-      }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...${fragments.repositoryOwnerFields}
-        }
-      }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...${fragments.userFields}
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...${fragments.repositoryOwnerFields}
-        }
-      }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeCommit {
-        ...${fragments.commitFields}
-      }
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...${fragments.teamMemberFields}
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
+  return `...on PullRequest {
+    additions
+    author {
+      ...${fragments.teamMemberFields}
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
       url
-    }`;
-  } else {
-    return `...on PullRequest {
-      additions
-      author {
-        ...${fragments.teamMemberFields}
+      owner {
+        ...${fragments.repositoryOwnerFields}
       }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...${fragments.repositoryOwnerFields}
-        }
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...${fragments.userFields}
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...${fragments.repositoryOwnerFields}
       }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...${fragments.userFields}
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...${fragments.repositoryOwnerFields}
-        }
-      }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...${fragments.teamMemberFields}
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
-      url
-    }`;
-  }
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    ${
+      isPublicRepo
+        ? `mergeCommit {
+      ...${fragments.commitFields}
+    }`
+        : ''
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...${fragments.teamMemberFields}
+    }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }`;
 };
 
 /**

--- a/src/client/GraphQLClient/pullRequestQueries/SinglePullRequestQuery.ts
+++ b/src/client/GraphQLClient/pullRequestQueries/SinglePullRequestQuery.ts
@@ -8,6 +8,7 @@ import {
   PullRequest,
 } from '../types';
 import { ExecutableQuery } from '../CreateQueryExecutor';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   isInitialQuery?: true;
@@ -61,7 +62,7 @@ export const buildQuery: BuildQuery<QueryParams, QueryState> = (
       ) {
           repository(name: $repoName, owner: $repoOwner) {
             pullRequest(number: $pullRequestNumber) {
-              ...pullRequestFields
+              ...${pullRequestFields}
               ${
                 queryState?.isInitialQuery ||
                 queryState?.commits?.hasNextPage === true
@@ -82,7 +83,7 @@ export const buildQuery: BuildQuery<QueryParams, QueryState> = (
               } 
             }
           }
-          ...rateLimit
+          ...${fragments.rateLimit}
       }`;
 
   return {
@@ -108,12 +109,74 @@ export const buildQuery: BuildQuery<QueryParams, QueryState> = (
   };
 };
 
+const pullRequestFields = `
+  on PullRequest {
+    additions
+    author {
+      ...${fragments.teamMemberFields}
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...${fragments.repositoryOwnerFields}
+      }
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...${fragments.userFields}
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...${fragments.repositoryOwnerFields}
+      }
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...${fragments.commitFields}
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...${fragments.teamMemberFields}
+    }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }`;
+
 const commitsQuery = `
     commits(first: $maxLimit, after: $commitsCursor) {
       totalCount
       nodes {
         commit {
-          ...commitFields
+          ...${fragments.commitFields}
         }
       }
       
@@ -127,7 +190,7 @@ const reviewsQuery = `
     reviews(first: $maxLimit, after: $reviewsCursor) {
       totalCount
       nodes {
-        ...reviewFields
+        ...${fragments.reviewFields}
       }
       pageInfo {
         endCursor

--- a/src/client/GraphQLClient/pullRequestQueries/__snapshots__/PullRequestsQuery.test.ts.snap
+++ b/src/client/GraphQLClient/pullRequestQueries/__snapshots__/PullRequestsQuery.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PullRequestsQuery #buildQuery first query - no query state 1`] = `
+exports[`PullRequestsQuery #buildQuery first private query - no query state 1`] = `
 Object {
   "query": "
       query (
@@ -13,28 +13,109 @@ Object {
           issueCount
           edges {
             node {
-              ...pullRequestFields
-              
-    ... on PullRequest {
-      commits(first: $maxLimit) {
-        totalCount
-        nodes {
-          commit {
-            ...commitFields
-          }
-        }
-        pageInfo {
-          endCursor
-          hasNextPage
+              ...on PullRequest {
+      additions
+      author {
+        ...on User {
+    name
+    login
+  }
+      }
+      authorAssociation
+      baseRefName
+      baseRefOid
+      baseRepository {
+        name
+        url
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
         }
       }
+      body
+      changedFiles
+      checksUrl
+      closed
+      closedAt
+      # comments  # Maybe someday
+      createdAt
+      databaseId
+      deletions
+      editor {
+        ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+      }
+      # files # Maybe someday
+      headRefName
+      headRefOid
+      headRepository {
+        name
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      id
+      isDraft
+      lastEditedAt
+      locked
+      mergeable
+      merged
+      mergedAt
+      mergedBy {
+        ...on User {
+    name
+    login
+  }
+      }
+      number
+      permalink
+      publishedAt
+      reviewDecision
+      # reviewRequests  # Maybe someday
+      state
+      # suggestedReviewers  # Maybe someday
+      title
+      updatedAt
+      url
     }
+              
               
     ... on PullRequest {
       reviews(first: $maxLimit) {
         totalCount
         nodes {
-          ...reviewFields
+          ...on PullRequestReview {
+    id
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
         }
         pageInfo {
           endCursor
@@ -63,7 +144,221 @@ Object {
             hasNextPage
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
+      }",
+  "queryVariables": Object {
+    "issueQuery": "is:pr repo:J1-Test/musical-palm-tree updated:>=2011-10-05T14:48:00.000Z",
+    "maxLimit": 100,
+    "maxSearchLimit": 25,
+  },
+}
+`;
+
+exports[`PullRequestsQuery #buildQuery first query - no query state 1`] = `
+Object {
+  "query": "
+      query (
+        $issueQuery: String!, 
+        $maxSearchLimit: Int!,
+        $maxLimit: Int!,
+        $pullRequestsCursor: String
+      ) {
+        search(first: $maxSearchLimit, after: $pullRequestsCursor, type: ISSUE, query: $issueQuery) {
+          issueCount
+          edges {
+            node {
+              ...on PullRequest {
+      additions
+      author {
+        ...on User {
+    name
+    login
+  }
+      }
+      authorAssociation
+      baseRefName
+      baseRefOid
+      baseRepository {
+        name
+        url
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      body
+      changedFiles
+      checksUrl
+      closed
+      closedAt
+      # comments  # Maybe someday
+      createdAt
+      databaseId
+      deletions
+      editor {
+        ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+      }
+      # files # Maybe someday
+      headRefName
+      headRefOid
+      headRepository {
+        name
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      id
+      isDraft
+      lastEditedAt
+      locked
+      mergeCommit {
+        ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+      }
+      mergeable
+      merged
+      mergedAt
+      mergedBy {
+        ...on User {
+    name
+    login
+  }
+      }
+      number
+      permalink
+      publishedAt
+      reviewDecision
+      # reviewRequests  # Maybe someday
+      state
+      # suggestedReviewers  # Maybe someday
+      title
+      updatedAt
+      url
+    }
+              
+    ... on PullRequest {
+      commits(first: $maxLimit) {
+        totalCount
+        nodes {
+          commit {
+            ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+              
+    ... on PullRequest {
+      reviews(first: $maxLimit) {
+        totalCount
+        nodes {
+          ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+              
+  ... on PullRequest {
+    labels(first: $maxLimit) {
+      totalCount
+      nodes {
+        id
+        name
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  } 
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "issueQuery": "is:pr repo:J1-Test/musical-palm-tree updated:>=2011-10-05T14:48:00.000Z",
@@ -86,14 +381,126 @@ Object {
           issueCount
           edges {
             node {
-              ...pullRequestFields
+              ...on PullRequest {
+      additions
+      author {
+        ...on User {
+    name
+    login
+  }
+      }
+      authorAssociation
+      baseRefName
+      baseRefOid
+      baseRepository {
+        name
+        url
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      body
+      changedFiles
+      checksUrl
+      closed
+      closedAt
+      # comments  # Maybe someday
+      createdAt
+      databaseId
+      deletions
+      editor {
+        ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+      }
+      # files # Maybe someday
+      headRefName
+      headRefOid
+      headRepository {
+        name
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      id
+      isDraft
+      lastEditedAt
+      locked
+      mergeCommit {
+        ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+      }
+      mergeable
+      merged
+      mergedAt
+      mergedBy {
+        ...on User {
+    name
+    login
+  }
+      }
+      number
+      permalink
+      publishedAt
+      reviewDecision
+      # reviewRequests  # Maybe someday
+      state
+      # suggestedReviewers  # Maybe someday
+      title
+      updatedAt
+      url
+    }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
         totalCount
         nodes {
           commit {
-            ...commitFields
+            ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
           }
         }
         pageInfo {
@@ -107,7 +514,22 @@ Object {
       reviews(first: $maxLimit) {
         totalCount
         nodes {
-          ...reviewFields
+          ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
         }
         pageInfo {
           endCursor
@@ -136,7 +558,14 @@ Object {
             hasNextPage
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "issueQuery": "is:pr repo:J1-Test/musical-palm-tree updated:>=2011-10-05T14:48:00.000Z",
@@ -201,14 +630,126 @@ Object {
           issueCount
           edges {
             node {
-              ...pullRequestFields
+              ...on PullRequest {
+      additions
+      author {
+        ...on User {
+    name
+    login
+  }
+      }
+      authorAssociation
+      baseRefName
+      baseRefOid
+      baseRepository {
+        name
+        url
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      body
+      changedFiles
+      checksUrl
+      closed
+      closedAt
+      # comments  # Maybe someday
+      createdAt
+      databaseId
+      deletions
+      editor {
+        ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+      }
+      # files # Maybe someday
+      headRefName
+      headRefOid
+      headRepository {
+        name
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      id
+      isDraft
+      lastEditedAt
+      locked
+      mergeCommit {
+        ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+      }
+      mergeable
+      merged
+      mergedAt
+      mergedBy {
+        ...on User {
+    name
+    login
+  }
+      }
+      number
+      permalink
+      publishedAt
+      reviewDecision
+      # reviewRequests  # Maybe someday
+      state
+      # suggestedReviewers  # Maybe someday
+      title
+      updatedAt
+      url
+    }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
         totalCount
         nodes {
           commit {
-            ...commitFields
+            ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
           }
         }
         pageInfo {
@@ -222,7 +763,22 @@ Object {
       reviews(first: $maxLimit) {
         totalCount
         nodes {
-          ...reviewFields
+          ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
         }
         pageInfo {
           endCursor
@@ -251,7 +807,14 @@ Object {
             hasNextPage
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "issueQuery": "is:pr repo:J1-Test/happy-sunshine updated:>=2011-10-05T14:48:00.000Z",
@@ -275,13 +838,126 @@ Object {
       ) {
           repository(name: $repoName, owner: $repoOwner) {
             pullRequest(number: $pullRequestNumber) {
-              ...pullRequestFields
+              ...
+  on PullRequest {
+    additions
+    author {
+      ...on User {
+    name
+    login
+  }
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
+    name
+    login
+  }
+    }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
     commits(first: $maxLimit, after: $commitsCursor) {
       totalCount
       nodes {
         commit {
-          ...commitFields
+          ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
         }
       }
       
@@ -294,7 +970,22 @@ Object {
     reviews(first: $maxLimit, after: $reviewsCursor) {
       totalCount
       nodes {
-        ...reviewFields
+        ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
       }
       pageInfo {
         endCursor
@@ -315,7 +1006,14 @@ Object {
     } 
             }
           }
-          ...rateLimit
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "maxLimit": 100,
@@ -340,13 +1038,128 @@ Object {
       ) {
           repository(name: $repoName, owner: $repoOwner) {
             pullRequest(number: $pullRequestNumber) {
-              ...pullRequestFields
+              ...
+  on PullRequest {
+    additions
+    author {
+      ...on User {
+    name
+    login
+  }
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
+    name
+    login
+  }
+    }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
               
     reviews(first: $maxLimit, after: $reviewsCursor) {
       totalCount
       nodes {
-        ...reviewFields
+        ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
       }
       pageInfo {
         endCursor
@@ -367,7 +1180,14 @@ Object {
     } 
             }
           }
-          ...rateLimit
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "labelsCursor": "Y3Vyc2==",
@@ -438,14 +1258,126 @@ Object {
           issueCount
           edges {
             node {
-              ...pullRequestFields
+              ...on PullRequest {
+      additions
+      author {
+        ...on User {
+    name
+    login
+  }
+      }
+      authorAssociation
+      baseRefName
+      baseRefOid
+      baseRepository {
+        name
+        url
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      body
+      changedFiles
+      checksUrl
+      closed
+      closedAt
+      # comments  # Maybe someday
+      createdAt
+      databaseId
+      deletions
+      editor {
+        ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+      }
+      # files # Maybe someday
+      headRefName
+      headRefOid
+      headRepository {
+        name
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      id
+      isDraft
+      lastEditedAt
+      locked
+      mergeCommit {
+        ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+      }
+      mergeable
+      merged
+      mergedAt
+      mergedBy {
+        ...on User {
+    name
+    login
+  }
+      }
+      number
+      permalink
+      publishedAt
+      reviewDecision
+      # reviewRequests  # Maybe someday
+      state
+      # suggestedReviewers  # Maybe someday
+      title
+      updatedAt
+      url
+    }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
         totalCount
         nodes {
           commit {
-            ...commitFields
+            ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
           }
         }
         pageInfo {
@@ -459,7 +1391,22 @@ Object {
       reviews(first: $maxLimit) {
         totalCount
         nodes {
-          ...reviewFields
+          ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
         }
         pageInfo {
           endCursor
@@ -488,7 +1435,14 @@ Object {
             hasNextPage
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "issueQuery": "is:pr repo:J1-Test/happy-sunshine updated:>=2011-10-05T14:48:00.000Z",
@@ -511,14 +1465,126 @@ Object {
           issueCount
           edges {
             node {
-              ...pullRequestFields
+              ...on PullRequest {
+      additions
+      author {
+        ...on User {
+    name
+    login
+  }
+      }
+      authorAssociation
+      baseRefName
+      baseRefOid
+      baseRepository {
+        name
+        url
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      body
+      changedFiles
+      checksUrl
+      closed
+      closedAt
+      # comments  # Maybe someday
+      createdAt
+      databaseId
+      deletions
+      editor {
+        ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+      }
+      # files # Maybe someday
+      headRefName
+      headRefOid
+      headRepository {
+        name
+        owner {
+          ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+        }
+      }
+      id
+      isDraft
+      lastEditedAt
+      locked
+      mergeCommit {
+        ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+      }
+      mergeable
+      merged
+      mergedAt
+      mergedBy {
+        ...on User {
+    name
+    login
+  }
+      }
+      number
+      permalink
+      publishedAt
+      reviewDecision
+      # reviewRequests  # Maybe someday
+      state
+      # suggestedReviewers  # Maybe someday
+      title
+      updatedAt
+      url
+    }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
         totalCount
         nodes {
           commit {
-            ...commitFields
+            ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
           }
         }
         pageInfo {
@@ -532,7 +1598,22 @@ Object {
       reviews(first: $maxLimit) {
         totalCount
         nodes {
-          ...reviewFields
+          ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
         }
         pageInfo {
           endCursor
@@ -561,7 +1642,14 @@ Object {
             hasNextPage
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "issueQuery": "is:pr repo:J1-Test/happy-sunshine updated:>=2011-10-05T14:48:00.000Z",

--- a/src/client/GraphQLClient/pullRequestQueries/__snapshots__/PullRequestsQuery.test.ts.snap
+++ b/src/client/GraphQLClient/pullRequestQueries/__snapshots__/PullRequestsQuery.test.ts.snap
@@ -14,38 +14,38 @@ Object {
           edges {
             node {
               ...on PullRequest {
-      additions
-      author {
-        ...on User {
+    additions
+    author {
+      ...on User {
     name
     login
   }
-      }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...on RepositoryOwner {
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...on User {
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
     login
     name
     isSiteAdmin
@@ -59,44 +59,45 @@ Object {
     url
     websiteUrl
   }
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...on RepositoryOwner {
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...on User {
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
     name
     login
   }
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
-      url
     }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
               
     ... on PullRequest {
@@ -175,38 +176,38 @@ Object {
           edges {
             node {
               ...on PullRequest {
-      additions
-      author {
-        ...on User {
+    additions
+    author {
+      ...on User {
     name
     login
   }
-      }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...on RepositoryOwner {
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...on User {
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
     login
     name
     isSiteAdmin
@@ -220,26 +221,26 @@ Object {
     url
     websiteUrl
   }
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...on RepositoryOwner {
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeCommit {
-        ...on Commit {
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
     id
     oid
     message
@@ -253,27 +254,27 @@ Object {
       }
     }
   }
-      }
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...on User {
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
     name
     login
   }
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
-      url
     }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
@@ -382,38 +383,38 @@ Object {
           edges {
             node {
               ...on PullRequest {
-      additions
-      author {
-        ...on User {
+    additions
+    author {
+      ...on User {
     name
     login
   }
-      }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...on RepositoryOwner {
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...on User {
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
     login
     name
     isSiteAdmin
@@ -427,26 +428,26 @@ Object {
     url
     websiteUrl
   }
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...on RepositoryOwner {
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeCommit {
-        ...on Commit {
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
     id
     oid
     message
@@ -460,27 +461,27 @@ Object {
       }
     }
   }
-      }
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...on User {
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
     name
     login
   }
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
-      url
     }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
@@ -631,38 +632,38 @@ Object {
           edges {
             node {
               ...on PullRequest {
-      additions
-      author {
-        ...on User {
+    additions
+    author {
+      ...on User {
     name
     login
   }
-      }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...on RepositoryOwner {
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...on User {
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
     login
     name
     isSiteAdmin
@@ -676,26 +677,26 @@ Object {
     url
     websiteUrl
   }
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...on RepositoryOwner {
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeCommit {
-        ...on Commit {
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
     id
     oid
     message
@@ -709,27 +710,27 @@ Object {
       }
     }
   }
-      }
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...on User {
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
     name
     login
   }
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
-      url
     }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
@@ -1259,38 +1260,38 @@ Object {
           edges {
             node {
               ...on PullRequest {
-      additions
-      author {
-        ...on User {
+    additions
+    author {
+      ...on User {
     name
     login
   }
-      }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...on RepositoryOwner {
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...on User {
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
     login
     name
     isSiteAdmin
@@ -1304,26 +1305,26 @@ Object {
     url
     websiteUrl
   }
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...on RepositoryOwner {
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeCommit {
-        ...on Commit {
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
     id
     oid
     message
@@ -1337,27 +1338,27 @@ Object {
       }
     }
   }
-      }
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...on User {
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
     name
     login
   }
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
-      url
     }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
     ... on PullRequest {
       commits(first: $maxLimit) {
@@ -1466,38 +1467,38 @@ Object {
           edges {
             node {
               ...on PullRequest {
-      additions
-      author {
-        ...on User {
+    additions
+    author {
+      ...on User {
     name
     login
   }
-      }
-      authorAssociation
-      baseRefName
-      baseRefOid
-      baseRepository {
-        name
-        url
-        owner {
-          ...on RepositoryOwner {
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      body
-      changedFiles
-      checksUrl
-      closed
-      closedAt
-      # comments  # Maybe someday
-      createdAt
-      databaseId
-      deletions
-      editor {
-        ...on User {
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
     login
     name
     isSiteAdmin
@@ -1511,26 +1512,26 @@ Object {
     url
     websiteUrl
   }
-      }
-      # files # Maybe someday
-      headRefName
-      headRefOid
-      headRepository {
-        name
-        owner {
-          ...on RepositoryOwner {
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
     login
     id
     url
   }
-        }
       }
-      id
-      isDraft
-      lastEditedAt
-      locked
-      mergeCommit {
-        ...on Commit {
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
     id
     oid
     message
@@ -1544,27 +1545,27 @@ Object {
       }
     }
   }
-      }
-      mergeable
-      merged
-      mergedAt
-      mergedBy {
-        ...on User {
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
     name
     login
   }
-      }
-      number
-      permalink
-      publishedAt
-      reviewDecision
-      # reviewRequests  # Maybe someday
-      state
-      # suggestedReviewers  # Maybe someday
-      title
-      updatedAt
-      url
     }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
     ... on PullRequest {
       commits(first: $maxLimit) {

--- a/src/client/GraphQLClient/pullRequestQueries/__snapshots__/SinglePullRequestQuery.test.ts.snap
+++ b/src/client/GraphQLClient/pullRequestQueries/__snapshots__/SinglePullRequestQuery.test.ts.snap
@@ -14,13 +14,126 @@ Object {
       ) {
           repository(name: $repoName, owner: $repoOwner) {
             pullRequest(number: $pullRequestNumber) {
-              ...pullRequestFields
+              ...
+  on PullRequest {
+    additions
+    author {
+      ...on User {
+    name
+    login
+  }
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
+    name
+    login
+  }
+    }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
     commits(first: $maxLimit, after: $commitsCursor) {
       totalCount
       nodes {
         commit {
-          ...commitFields
+          ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
         }
       }
       
@@ -33,7 +146,22 @@ Object {
     reviews(first: $maxLimit, after: $reviewsCursor) {
       totalCount
       nodes {
-        ...reviewFields
+        ...on PullRequestReview {
+    id
+    commit {
+      oid
+    }
+    author {
+      ...on User {
+          name
+          login
+        }
+    }
+    state
+    submittedAt
+    updatedAt
+    url
+  }
       }
       pageInfo {
         endCursor
@@ -54,7 +182,14 @@ Object {
     } 
             }
           }
-          ...rateLimit
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "maxLimit": 100,
@@ -79,7 +214,107 @@ Object {
       ) {
           repository(name: $repoName, owner: $repoOwner) {
             pullRequest(number: $pullRequestNumber) {
-              ...pullRequestFields
+              ...
+  on PullRequest {
+    additions
+    author {
+      ...on User {
+    name
+    login
+  }
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
+    name
+    login
+  }
+    }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
               
               
@@ -96,7 +331,14 @@ Object {
     } 
             }
           }
-          ...rateLimit
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "labelsCursor": "labelsEndCursor",
@@ -122,7 +364,107 @@ Object {
       ) {
           repository(name: $repoName, owner: $repoOwner) {
             pullRequest(number: $pullRequestNumber) {
-              ...pullRequestFields
+              ...
+  on PullRequest {
+    additions
+    author {
+      ...on User {
+    name
+    login
+  }
+    }
+    authorAssociation
+    baseRefName
+    baseRefOid
+    baseRepository {
+      name
+      url
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    body
+    changedFiles
+    checksUrl
+    closed
+    closedAt
+    # comments  # Maybe someday
+    createdAt
+    databaseId
+    deletions
+    editor {
+      ...on User {
+    login
+    name
+    isSiteAdmin
+    company
+    createdAt
+    databaseId
+    email
+    isEmployee
+    location
+    updatedAt
+    url
+    websiteUrl
+  }
+    }
+    # files # Maybe someday
+    headRefName
+    headRefOid
+    headRepository {
+      name
+      owner {
+        ...on RepositoryOwner {
+    login
+    id
+    url
+  }
+      }
+    }
+    id
+    isDraft
+    lastEditedAt
+    locked
+    mergeCommit {
+      ...on Commit {
+    id
+    oid
+    message
+    authoredDate
+    changedFiles
+    commitUrl
+    author {
+      date
+      user {
+        login # this used to be ...userFields
+      }
+    }
+  }
+    }
+    mergeable
+    merged
+    mergedAt
+    mergedBy {
+      ...on User {
+    name
+    login
+  }
+    }
+    number
+    permalink
+    publishedAt
+    reviewDecision
+    # reviewRequests  # Maybe someday
+    state
+    # suggestedReviewers  # Maybe someday
+    title
+    updatedAt
+    url
+  }
               
               
               
@@ -139,7 +481,14 @@ Object {
     } 
             }
           }
-          ...rateLimit
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }",
   "queryVariables": Object {
     "labelsCursor": "Y3Vyc2==",

--- a/src/client/GraphQLClient/repositoryQueries/OrgRepositoriesQuery.ts
+++ b/src/client/GraphQLClient/repositoryQueries/OrgRepositoriesQuery.ts
@@ -9,6 +9,7 @@ import {
 } from '../types';
 import paginate from '../paginate';
 import utils from '../utils';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   repos: CursorState;
@@ -33,7 +34,7 @@ const buildQuery: BuildQuery<string, QueryState> = (
           repositories(first: $maxLimit, after: $repoCursor) {
             nodes {
               id
-					    ...repositoryFields
+					    ...${fragments.repositoryFields}
             }
             pageInfo {
               endCursor
@@ -41,7 +42,7 @@ const buildQuery: BuildQuery<string, QueryState> = (
             }
           }
         }
-        ...rateLimit
+        ...${fragments.rateLimit}
       }`;
 
   return {

--- a/src/client/GraphQLClient/repositoryQueries/TeamRepositoriesQuery.ts
+++ b/src/client/GraphQLClient/repositoryQueries/TeamRepositoriesQuery.ts
@@ -10,6 +10,7 @@ import {
 import { MAX_REQUESTS_LIMIT } from '../paginate';
 import paginate from '../paginate';
 import utils from '../utils';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   teamRepos?: CursorState;
@@ -56,7 +57,7 @@ const buildQuery: BuildQuery<QueryParams, QueryState> = (
               }
             }
           }
-          ...rateLimit
+          ...${fragments.rateLimit}
         }`;
 
   return {

--- a/src/client/GraphQLClient/repositoryQueries/__snapshots__/OrgRepositoriesQuery.test.ts.snap
+++ b/src/client/GraphQLClient/repositoryQueries/__snapshots__/OrgRepositoriesQuery.test.ts.snap
@@ -8,7 +8,36 @@ exports[`OrgRepositoriesQuery pagination of org repos 1`] = `
           repositories(first: $maxLimit, after: $repoCursor) {
             nodes {
               id
-					    ...repositoryFields
+					    ...on Repository {
+    name
+    nameWithOwner
+    url
+    isPrivate
+    isArchived
+    createdAt
+    updatedAt
+    autoMergeAllowed
+    databaseId
+    deleteBranchOnMerge
+    description
+    forkCount
+    forkingAllowed
+    homepageUrl
+    isDisabled
+    isEmpty
+    isFork
+    isInOrganization
+    isLocked
+    isMirror
+    isSecurityPolicyEnabled
+    isTemplate
+    isUserConfigurationRepository
+    lockReason
+    mergeCommitAllowed
+    pushedAt
+    rebaseMergeAllowed
+    url
+  }
             }
             pageInfo {
               endCursor
@@ -16,6 +45,13 @@ exports[`OrgRepositoriesQuery pagination of org repos 1`] = `
             }
           }
         }
-        ...rateLimit
+        ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
       }"
 `;

--- a/src/client/GraphQLClient/repositoryQueries/__snapshots__/TeamRepositoriesQuery.test.ts.snap
+++ b/src/client/GraphQLClient/repositoryQueries/__snapshots__/TeamRepositoriesQuery.test.ts.snap
@@ -29,6 +29,13 @@ exports[`TeamRepositoriesQuery pagination of team repos 1`] = `
               }
             }
           }
-          ...rateLimit
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
         }"
 `;

--- a/src/client/GraphQLClient/teamQueries/TeamsQuery.ts
+++ b/src/client/GraphQLClient/teamQueries/TeamsQuery.ts
@@ -9,6 +9,7 @@ import {
 import { MAX_REQUESTS_LIMIT } from '../paginate';
 import paginate from '../paginate';
 import utils from '../utils';
+import fragments from '../fragments';
 
 interface QueryState extends BaseQueryState {
   teams: CursorState;
@@ -23,7 +24,7 @@ const buildQuery: BuildQuery<string, QueryState> = (login, queryState) => {
           edges {
             node {
               id
-              ...teamFields
+              ...${fragments.teamFields}
             }
           }
           pageInfo {
@@ -32,7 +33,7 @@ const buildQuery: BuildQuery<string, QueryState> = (login, queryState) => {
           }
         }
       }
-      ...rateLimit
+      ...${fragments.rateLimit}
     }`;
 
   return {

--- a/src/client/GraphQLClient/teamQueries/__snapshots__/TeamsQuery.test.ts.snap
+++ b/src/client/GraphQLClient/teamQueries/__snapshots__/TeamsQuery.test.ts.snap
@@ -9,7 +9,16 @@ exports[`TeamMembersQuery pagination of teams 1`] = `
           edges {
             node {
               id
-              ...teamFields
+              ...on Team {
+    name
+    url
+    slug    
+    createdAt
+    updatedAt
+    databaseId
+    description
+    privacy
+  }
             }
           }
           pageInfo {
@@ -18,6 +27,13 @@ exports[`TeamMembersQuery pagination of teams 1`] = `
           }
         }
       }
-      ...rateLimit
+      ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
     }"
 `;

--- a/src/util/createGitHubAppClient.ts
+++ b/src/util/createGitHubAppClient.ts
@@ -13,7 +13,7 @@ export default function createGitHubAppClient(
   restApiBaseUrl: string,
   config: IntegrationConfig,
   logger: IntegrationLogger,
-) {
+): Octokit {
   const appId = config.githubAppId;
   const installationId = config.installationId;
   const privateKey = config.githubAppPrivateKey;
@@ -34,7 +34,7 @@ export default function createGitHubAppClient(
    * The auth hook also authenticates requests, manages cached JWTs and tokens,
    * and authenticates using the installation ID passed to createAppAuth.
    */
-  const v3 = new OctokitThrottling({
+  return new OctokitThrottling({
     userAgent: 'jupiter-integration-github',
     baseUrl: restApiBaseUrl,
     authStrategy: createAppAuth,
@@ -64,6 +64,4 @@ export default function createGitHubAppClient(
       },
     },
   });
-
-  return v3;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,6 +947,19 @@
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/core@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
+  integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.3"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/endpoint@^6.0.1":
   version "6.0.12"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.12.tgz#3b4d47a4b0e79b1027fb8d75d4221928b2d05658"
@@ -986,24 +999,29 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-10.6.4.tgz#c8b5b1f5c60ab7c62858abe2ef57bc709f426a30"
   integrity sha512-JVmwWzYTIs6jACYOwD6zu5rdrqGIYsiAsLzTCxdrWIPNKNVjEF6vPTL20shmgJ4qZsq7WPBcLXLsaQD+NLChfg==
 
-"@octokit/plugin-paginate-rest@^2.16.4":
-  version "2.16.7"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.7.tgz#d25b6e650ba5a007002986f5fda66958d44e70a4"
-  integrity sha512-TMlyVhMPx6La1Ud4PSY4YxqAvb9YPEMs/7R1nBSbsw4wNqG73aBqls0r0dRRCWe5Pm0ZUGS9a94N46iAxlOR8A==
+"@octokit/openapi-types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
+  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
+
+"@octokit/plugin-paginate-rest@^2.16.8":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
+  integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
   dependencies:
-    "@octokit/types" "^6.31.3"
+    "@octokit/types" "^6.34.0"
 
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
-"@octokit/plugin-rest-endpoint-methods@5.11.4":
-  version "5.11.4"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.11.4.tgz#221dedcbdc45d6bfa54228d469e8c34acb4e0e34"
-  integrity sha512-iS+GYTijrPUiEiLoDsGJhrbXIvOPfm2+schvr+FxNMs7PeE9Nl4bAMhE8ftfNX3Z1xLxSKwEZh0O7GbWurX5HQ==
+"@octokit/plugin-rest-endpoint-methods@^5.12.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
+  integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
   dependencies:
-    "@octokit/types" "^6.31.2"
+    "@octokit/types" "^6.34.0"
     deprecation "^2.3.1"
 
 "@octokit/plugin-retry@^3.0.9":
@@ -1014,10 +1032,10 @@
     "@octokit/types" "^6.0.3"
     bottleneck "^2.15.3"
 
-"@octokit/plugin-throttling@^3.5.2":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-3.5.2.tgz#8b1797a5f14edbca0b8af619394056ed0ed5c9b5"
-  integrity sha512-Eu7kfJxU8vmHqWGNszWpg+GVp2tnAfax3XQV5CkYPEE69C+KvInJXW9WajgSeW+cxYe0UVdouzCtcreGNuJo7A==
+"@octokit/plugin-throttling@^3.6.2":
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-3.6.2.tgz#abfc045309b8e46f6d6b6c01047eb41c4031f2f8"
+  integrity sha512-0az5fxgVlhFfFtiKLKVXTpmCG2tK3BG0fYI8SO4pmGlN1kyJktJVQA+6KKaFxtxMIWsuHmSEAkR6zSgtk86g2A==
   dependencies:
     "@octokit/types" "^6.0.1"
     bottleneck "^2.15.3"
@@ -1031,7 +1049,7 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.3.0", "@octokit/request@^5.4.14", "@octokit/request@^5.6.0", "@octokit/request@^5.6.1":
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.14", "@octokit/request@^5.6.0":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.1.tgz#f97aff075c37ab1d427c49082fefeef0dba2d8ce"
   integrity sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==
@@ -1043,22 +1061,41 @@
     node-fetch "^2.6.1"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^18.11.4":
-  version "18.11.4"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.11.4.tgz#9fb6d826244554fbf8c110b9064018d7198eec51"
-  integrity sha512-QplypCyYxqMK05JdMSm/bDWZO8VWWaBdzQ9tbF9rEV9rIEiICh+v6q+Vu/Y5hdze8JJaxfUC+PBC7vrnEkZvZg==
+"@octokit/request@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.7"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^18.12.0":
+  version "18.12.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
+  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
   dependencies:
     "@octokit/core" "^3.5.1"
-    "@octokit/plugin-paginate-rest" "^2.16.4"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
     "@octokit/plugin-request-log" "^1.0.4"
-    "@octokit/plugin-rest-endpoint-methods" "5.11.4"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
-"@octokit/types@^6.0.1", "@octokit/types@^6.0.3", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.16.1", "@octokit/types@^6.31.2", "@octokit/types@^6.31.3":
+"@octokit/types@^6.0.1", "@octokit/types@^6.0.3", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.16.1":
   version "6.31.3"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.31.3.tgz#14c2961baea853b2bf148d892256357a936343f8"
   integrity sha512-IUG3uMpsLHrtEL6sCVXbxCgnbKcgpkS4K7gVEytLDvYYalkK3XcuMCHK1YPD8xJglSJAOAbL4MgXp47rS9G49w==
   dependencies:
     "@octokit/openapi-types" "^10.6.4"
+
+"@octokit/types@^6.34.0":
+  version "6.34.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
+  integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
+  dependencies:
+    "@octokit/openapi-types" "^11.2.0"
 
 "@pollyjs/adapter-node-http@^6.0.5":
   version "6.0.5"
@@ -4156,6 +4193,13 @@ node-fetch@^2.6.1:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
   integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,7 +956,7 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/graphql@^4.5.8":
+"@octokit/graphql@^4.5.8", "@octokit/graphql@^4.8.0":
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
   integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
@@ -2864,11 +2864,6 @@ graceful-fs@^4.2.9:
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
-
-graphql.js@^0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/graphql.js/-/graphql.js-0.6.8.tgz#5c2e57311b5e74c6665ff9394394bc76f273542f"
-  integrity sha512-y1OxsvPCfBell00yb2T1E+JQjFXzbmqDT3hsf7Ckof80DlRuQ3SrmLL7KC04Up81vlBj+l9opYJjDLf9OgMH3w==
 
 hammerjs@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
To prevent low level errors, we moved away from graphql.js package to octokit/graphql.js package. This appears to be a more robust and well maintained package from GitHub. 
We lost `fragments` feature. String interpolation is essentially what it was doing and those represent a bulk of the changes.
Snapshots were updated as well since the fragments feature didn't execute prior to snapshotting the query.

The new package handles the baseUrl differently. It appends `/graphql` for us.