### PR TITLE
INT 3556 octokit errors

### DIFF
--- a/src/client/GraphQLClient/README.md
+++ b/src/client/GraphQLClient/README.md
@@ -59,7 +59,201 @@ Each query requires:
 
 ## Example GraphQL Errors
 
-1. Caused when querying for an org that doesn't exist\*\*
+### 2022-4-28: Update error handling and examples
+
+Check out the client documentation
+https://github.com/octokit/graphql.js/#errors. This is a redacted example of a
+FORBIDDEN error. Note that a partial dataset is included in the response.
+
+```json5
+{
+  request: {
+    query: '\n query (\n $pullRequestNumber: Int!\n $repoName: String!\n $repoOwner: String!\n $maxLimit: Int!\n $commitsCursor: String\n $reviewsCursor: String\n $labelsCursor: String\n ) {\n repository(name: $repoName, owner: $repoOwner) {\n pullRequest(number: $pullRequestNumber) {\n ...\n on PullRequest {\n additions\n author {\n ...on User {\n name\n login\n }\n }\n authorAssociation\n baseRefName\n baseRefOid\n baseRepository {\n name\n url\n owner {\n ...on RepositoryOwner {\n login\n id\n url\n }\n }\n }\n body\n changedFiles\n checksUrl\n closed\n closedAt\n # comments # Maybe someday\n createdAt\n databaseId\n deletions\n editor {\n ...on User {\n login\n name\n isSiteAdmin\n company\n createdAt\n databaseId\n email\n isEmployee\n location\n updatedAt\n url\n websiteUrl\n }\n }\n # files # Maybe someday\n headRefName\n headRefOid\n headRepository {\n name\n owner {\n ...on RepositoryOwner {\n login\n id\n url\n }\n }\n }\n id\n isDraft\n lastEditedAt\n locked\n mergeCommit {\n ...on Commit {\n id\n oid\n message\n authoredDate\n changedFiles\n commitUrl\n author {\n date\n user {\n login # this used to be ...userFields\n }\n }\n }\n }\n mergeable\n merged\n mergedAt\n mergedBy {\n ...on User {\n name\n login\n }\n }\n number\n permalink\n publishedAt\n reviewDecision\n # reviewRequests # Maybe someday\n state\n # suggestedReviewers # Maybe someday\n title\n updatedAt\n url\n }\n \n commits(first: $maxLimit, after: $commitsCursor) {\n totalCount\n nodes {\n commit {\n ...on Commit {\n id\n oid\n message\n authoredDate\n changedFiles\n commitUrl\n author {\n date\n user {\n login # this used to be ...userFields\n }\n }\n }\n }\n }\n \n pageInfo {\n endCursor\n hasNextPage\n }\n }\n \n reviews(first: $maxLimit, after: $reviewsCursor) {\n totalCount\n nodes {\n ...on PullRequestReview {\n id\n commit {\n oid\n }\n author {\n ...on User {\n name\n login\n }\n }\n state\n submittedAt\n updatedAt\n url\n }\n }\n pageInfo {\n endCursor\n hasNextPage\n }\n }\n \n labels(first: $maxLimit, after: $labelsCursor) {\n totalCount\n nodes {\n id\n name\n }\n pageInfo {\n endCursor\n hasNextPage\n }\n } \n }\n }\n ...on Query {\n rateLimit {\n limit\n cost\n remaining\n resetAt\n }\n }\n }',
+    variables: {
+      pullRequestNumber: 9988,
+      repoName: 'Bob-Backend',
+      repoOwner: 'bob',
+      maxLimit: 100,
+    },
+  },
+  headers: {
+    'access-control-allow-origin': '*',
+    'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset',
+    connection: 'close',
+    'content-encoding': 'gzip',
+    'content-security-policy': "default-src 'none'",
+    'content-type': 'application/json; charset=utf-8',
+    date: 'Thu, 28 Apr 2022 02:28:18 GMT',
+    'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
+    server: 'GitHub.com',
+    'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
+    'transfer-encoding': 'chunked',
+    vary: 'Accept-Encoding, Accept, X-Requested-With',
+    'x-content-type-options': 'nosniff',
+    'x-frame-options': 'deny',
+    'x-github-media-type': 'github.v3; format=json',
+    'x-github-request-id': 'D404:0565:3FA285:9692F0:6269FBC1',
+    'x-ratelimit-limit': '12500',
+    'x-ratelimit-remaining': '11755',
+    'x-ratelimit-reset': '1651115149',
+    'x-ratelimit-resource': 'graphql',
+    'x-ratelimit-used': '745',
+    'x-xss-protection': '0',
+  },
+  response: {
+    data: 'see root level data object',
+    errors: 'see root level errors object',
+    queryString: 'see root level queryString property',
+    queryVariables: 'see root level queryVariables property',
+  },
+  name: 'GraphqlResponseError',
+  errors: [
+    {
+      type: 'FORBIDDEN',
+      path: ['repository', 'pullRequest', 'commits', 'nodes', 0],
+      extensions: {
+        saml_failure: false,
+      },
+      locations: [
+        {
+          line: 117,
+          column: 7,
+        },
+      ],
+      message: 'Resource not accessible by integration',
+    },
+    {
+      type: 'FORBIDDEN',
+      path: ['repository', 'pullRequest', 'commits', 'nodes', 1],
+      extensions: {
+        saml_failure: false,
+      },
+      locations: [
+        {
+          line: 117,
+          column: 7,
+        },
+      ],
+      message: 'Resource not accessible by integration',
+    },
+    {
+      type: 'FORBIDDEN',
+      path: ['repository', 'pullRequest', 'commits', 'nodes', 2],
+      extensions: {
+        saml_failure: false,
+      },
+      locations: [
+        {
+          line: 117,
+          column: 7,
+        },
+      ],
+      message: 'Resource not accessible by integration',
+    },
+  ],
+  data: {
+    repository: {
+      pullRequest: {
+        id: 'properties have been removed',
+        commits: {
+          totalCount: 11,
+          nodes: [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+          ],
+          pageInfo: {
+            endCursor: 'MTE',
+            hasNextPage: false,
+          },
+        },
+        reviews: {
+          totalCount: 117,
+          nodes: [
+            {
+              id: 'PRR_234',
+              commit: null,
+              author: {},
+              state: 'COMMENTED',
+              submittedAt: '2022-04-19T04:33:08Z',
+              updatedAt: '2022-04-19T04:33:08Z',
+              url: 'https://github.com/bob/Bob-Backend/pull/9988#pullrequestreview-945046107',
+            },
+            {
+              id: 'PRR_432',
+              commit: null,
+              author: {},
+              state: 'COMMENTED',
+              submittedAt: '2022-04-19T04:33:09Z',
+              updatedAt: '2022-04-19T04:33:09Z',
+              url: 'https://github.com/bob/Bob-Backend/pull/9988#pullrequestreview-945046115',
+            },
+            {
+              id: 'additional nodes were removed',
+            },
+          ],
+          pageInfo: {
+            endCursor: 'asdf==',
+            hasNextPage: true,
+          },
+        },
+        labels: {
+          totalCount: 0,
+          nodes: [],
+          pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+          },
+        },
+      },
+    },
+    rateLimit: {
+      limit: 12500,
+      cost: 1,
+      remaining: 11755,
+      resetAt: '2022-04-28T03:05:49Z',
+    },
+  },
+  queryString: '\n query (\n $pullRequestNumber: Int!\n $repoName: String!\n $repoOwner: String!\n $maxLimit: Int!\n $commitsCursor: String\n $reviewsCursor: String\n $labelsCursor: String\n ) {\n repository(name: $repoName, owner: $repoOwner) {\n pullRequest(number: $pullRequestNumber) {\n ...\n on PullRequest {\n additions\n author {\n ...on User {\n name\n login\n }\n }\n authorAssociation\n baseRefName\n baseRefOid\n baseRepository {\n name\n url\n owner {\n ...on RepositoryOwner {\n login\n id\n url\n }\n }\n }\n body\n changedFiles\n checksUrl\n closed\n closedAt\n # comments # Maybe someday\n createdAt\n databaseId\n deletions\n editor {\n ...on User {\n login\n name\n isSiteAdmin\n company\n createdAt\n databaseId\n email\n isEmployee\n location\n updatedAt\n url\n websiteUrl\n }\n }\n # files # Maybe someday\n headRefName\n headRefOid\n headRepository {\n name\n owner {\n ...on RepositoryOwner {\n login\n id\n url\n }\n }\n }\n id\n isDraft\n lastEditedAt\n locked\n mergeCommit {\n ...on Commit {\n id\n oid\n message\n authoredDate\n changedFiles\n commitUrl\n author {\n date\n user {\n login # this used to be ...userFields\n }\n }\n }\n }\n mergeable\n merged\n mergedAt\n mergedBy {\n ...on User {\n name\n login\n }\n }\n number\n permalink\n publishedAt\n reviewDecision\n # reviewRequests # Maybe someday\n state\n # suggestedReviewers # Maybe someday\n title\n updatedAt\n url\n }\n \n commits(first: $maxLimit, after: $commitsCursor) {\n totalCount\n nodes {\n commit {\n ...on Commit {\n id\n oid\n message\n authoredDate\n changedFiles\n commitUrl\n author {\n date\n user {\n login # this used to be ...userFields\n }\n }\n }\n }\n }\n \n pageInfo {\n endCursor\n hasNextPage\n }\n }\n \n reviews(first: $maxLimit, after: $reviewsCursor) {\n totalCount\n nodes {\n ...on PullRequestReview {\n id\n commit {\n oid\n }\n author {\n ...on User {\n name\n login\n }\n }\n state\n submittedAt\n updatedAt\n url\n }\n }\n pageInfo {\n endCursor\n hasNextPage\n }\n }\n \n labels(first: $maxLimit, after: $labelsCursor) {\n totalCount\n nodes {\n id\n name\n }\n pageInfo {\n endCursor\n hasNextPage\n }\n } \n }\n }\n ...on Query {\n rateLimit {\n limit\n cost\n remaining\n resetAt\n }\n }\n }',
+  queryVariables: {
+    pullRequestNumber: 9988,
+    repoName: 'asdf-Backend',
+    repoOwner: 'bob',
+    maxLimit: 100,
+  },
+}
+```
+
+2. Caused by bad token or expired token. Error type: HttpError, not
+   GraphqlResponseError
+
+```json
+{
+  "message": "Bad credentials",
+  "documentation_url": "https://docs.github.com/graphql"
+}
+```
+
+3. Caused by the GitHub API running into an issue. Could be query is pulling
+   back too many nodes and timesout.
+
+```
+Error: iteratePullRequests: GraphQL errors (1), first: {"message":"Something went wrong while executing your query. This may be the result of a timeout, or it could be a GitHub bug. Please include `9E12:6C93:1987D3B:2F6FFCF:6238E3EE` when reporting this issue."}
+```
+
+---
+
+## The errors below may not be valid. Please see above
+
+1. INVALID: Caused when querying for an org that doesn't exist\*\*
    \*\*OrganizationQuery.ts Note: the "data" portion of the error/response is
    not included. The GraphQL project must not include it. `error.errors` is what
    is given to the catch statement
@@ -82,17 +276,8 @@ Each query requires:
 }
 ```
 
-2. Caused by bad token or expired token
-
-```json
-{
-  "message": "Bad credentials",
-  "documentation_url": "https://docs.github.com/graphql"
-}
-```
-
-3. Caused by invalid field in query - no `type` is provided `error.errors` is
-   what is given to the catch statement
+3. INVALID: Caused by invalid field in query - no `type` is provided
+   `error.errors` is what is given to the catch statement
 
 ```json5
 {
@@ -146,7 +331,7 @@ Each query requires:
 }
 ```
 
-4. Caused by querying for a resource that doesn't exist. See message
+4. INVALID: Caused by querying for a resource that doesn't exist. See message
 
 ```
     [
@@ -167,7 +352,7 @@ Each query requires:
 ]
 ```
 
-5. Caused by not having access to a resource
+5. INVALID: Caused by not having access to a resource
 
 ```
 [
@@ -191,28 +376,12 @@ Each query requires:
 ]
 ```
 
-6. unknown cause
+6. unknown cause Update: appears this was not being handled appropriately by the
+   graphql.js project.
 
 ```
 SyntaxError: Unexpected end of JSON input
 at JSON.parse (<anonymous>)
 at IncomingMessage.<anonymous> (/opt/jupiterone/app/node_modules/graphql.js/graphql.js:73:25)
 at IncomingMessage.emit (events.js:387:35)
-```
-
-7. Caused by the fetch-account failing
-
-```
-Error: Expected to find Account entity in jobState.
-at Object.fetchPrs [as executionHandler] (/opt/jupiterone/app/node_modules/@jupiterone/graph-github/dist/steps/pullRequests.js:21:15)
-at async executeStep (/opt/jupiterone/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/execution/dependencyGraph.js:212:21)
-at async timeOperation (/opt/jupiterone/app/node_modules/@jupiterone/integration-sdk-runtime/dist/src/metrics/index.js:6:12)
-at async run (/opt/jupiterone/app/node_modules/p-queue/dist/index.js:163:29)
-```
-
-8. Caused by the GitHub API running into an issue. Could be query is pulling
-   back too many nodes and timesout.
-
-```
-Error: iteratePullRequests: GraphQL errors (1), first: {"message":"Something went wrong while executing your query. This may be the result of a timeout, or it could be a GitHub bug. Please include `9E12:6C93:1987D3B:2F6FFCF:6238E3EE` when reporting this issue."}
 ```

--- a/src/client/GraphQLClient/__snapshots__/utils.test.ts.snap
+++ b/src/client/GraphQLClient/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`utils responseToResource 1`] = `
+Object {
+  "commits": Array [
+    Object {
+      "asdf": "commit",
+    },
+  ],
+  "id": "PR_asdf",
+  "labels": Array [
+    Object {
+      "asdf": "label",
+    },
+  ],
+  "reviews": Array [
+    Object {
+      "author": Object {},
+      "commit": null,
+      "id": "asdf",
+      "state": "COMMENTED",
+      "submittedAt": "2000-04-19T04:33:08Z",
+      "updatedAt": "2000-04-19T04:33:08Z",
+      "url": "https://github.com/",
+    },
+  ],
+}
+`;

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -391,10 +391,10 @@ export class GitHubGraphQLClient {
               // Partial data can be included in errors.
               ...error.data,
             };
-          } else {
-            throw error;
           }
         }
+
+        throw error;
       }
     };
 

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -1,4 +1,7 @@
-import { graphql as octokitGraphQl } from '@octokit/graphql';
+import {
+  graphql as octokitGraphQl,
+  GraphqlResponseError,
+} from '@octokit/graphql';
 
 import {
   IntegrationLogger,
@@ -369,33 +372,27 @@ export class GitHubGraphQLClient {
           'Attempting GraphQL request',
         );
         return await this.graph(queryString, queryVariables);
-      } catch (err) {
+      } catch (error) {
         logger.debug(
-          { queryString, queryVariables, timeoutRetryAttempt, err },
+          { queryString, queryVariables, timeoutRetryAttempt, error },
           'GraphQL request failed.',
         );
 
-        // Add queryString & queryVariables to error.
-        if (Array.isArray(err) && err.length > 0) {
-          err[0].queryString = queryString;
-          err[0].queryVariables = queryVariables;
-        } else {
-          err.queryString = queryString;
-          err.queryVariables = queryVariables;
-        }
-
-        // Handle pre-retry logic
-        // If resource can't be found, or is not accessible,
-        // continue with processing.
-        if (
-          handleNotFoundErrors(err, logger) ||
-          handleForbiddenErrors(err, logger)
-        ) {
-          return {
-            rateLimit: {},
-          };
-        } else {
-          throw err;
+        if (error instanceof GraphqlResponseError) {
+          // Handle pre-retry logic
+          // If resource can't be found, or is not accessible,
+          // continue with processing.
+          if (
+            handleNotFoundErrors(error.errors, logger) ||
+            handleForbiddenErrors(error.errors, logger)
+          ) {
+            return {
+              rateLimit: {},
+              ...error.data,
+            };
+          } else {
+            throw error;
+          }
         }
       }
     };

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -388,6 +388,7 @@ export class GitHubGraphQLClient {
           ) {
             return {
               rateLimit: {},
+              // Partial data can be included in errors.
               ...error.data,
             };
           } else {

--- a/src/client/GraphQLClient/errorHandlers.test.ts
+++ b/src/client/GraphQLClient/errorHandlers.test.ts
@@ -112,43 +112,7 @@ describe('errorHandlers', () => {
     });
     test('bad cred', async () => {
       // Arrange
-      const error = new GraphqlResponseError(
-        null as any,
-        null as any,
-        { errors: [{ message: 'Bad credentials' }] } as any,
-      );
-      const info = jest.fn();
-      const abort = jest.fn();
-      const refresh = jest.fn();
-      const logger = {
-        info,
-      } as unknown as IntegrationLogger;
-      const attemptContext = {
-        abort,
-      } as unknown as AttemptContext;
-
-      // Act
-      await retryErrorHandle(error, logger, attemptContext, refresh);
-
-      // Arrange
-      expect(info).toHaveBeenCalled();
-      expect(refresh).toHaveBeenCalled();
-      expect(abort).not.toHaveBeenCalled();
-    });
-    test('secondary rate limit', async () => {
-      // Arrange
-      const error = new GraphqlResponseError(
-        null as any,
-        null as any,
-        {
-          errors: [
-            {
-              message: 'Bad credentials',
-              documentation_url: 'google.it',
-            },
-          ],
-        } as any,
-      );
+      const error = new Error('Bad credentials');
       const info = jest.fn();
       const abort = jest.fn();
       const refresh = jest.fn();

--- a/src/client/GraphQLClient/errorHandlers.ts
+++ b/src/client/GraphQLClient/errorHandlers.ts
@@ -75,22 +75,22 @@ export const retryErrorHandle = async (
       error.errors?.some((e) => e.type === 'RATE_LIMITED')
     ) {
       logger.info({ attemptContext, error }, 'Rate limiting message received.');
-    } else if (error.message?.includes('Bad credentials')) {
-      logger.info({ error }, 'Bad credentials: Refreshing token.');
-      await refreshToken();
-    } else if (error.message?.includes('exceeded a secondary rate limit')) {
-      logger.info(
-        { attemptContext, error },
-        '"Secondary Rate Limit" message received. Waiting before retrying.',
-      );
-      await sleep(300_000);
-    } else if (
-      error.message?.includes('Something went wrong while executing your query')
-    ) {
-      logger.info(
-        { attemptContext, error },
-        `A downstream error occurred on the GitHub API. It may have been caused by a large query thus causing a timeout.`,
-      );
     }
+  } else if (error.message?.includes('Bad credentials')) {
+    logger.info({ error }, 'Bad credentials: Refreshing token.');
+    await refreshToken();
+  } else if (error.message?.includes('exceeded a secondary rate limit')) {
+    logger.info(
+      { attemptContext, error },
+      '"Secondary Rate Limit" message received. Waiting before retrying.',
+    );
+    await sleep(300_000);
+  } else if (
+    error.message?.includes('Something went wrong while executing your query')
+  ) {
+    logger.info(
+      { attemptContext, error },
+      `A downstream error occurred on the GitHub API. It may have been caused by a large query thus causing a timeout.`,
+    );
   }
 };

--- a/src/client/GraphQLClient/errorHandlers.ts
+++ b/src/client/GraphQLClient/errorHandlers.ts
@@ -5,6 +5,7 @@ import { GraphqlResponseError } from '@octokit/graphql';
 
 /**
  * If the errors are all the same specified type, ignore them.
+ * TODO: (VDubber) Consider reporting this skipped error once capability is available in SDK.
  * @param errors
  * @param logger
  * @param type

--- a/src/client/GraphQLClient/errorHandlers.ts
+++ b/src/client/GraphQLClient/errorHandlers.ts
@@ -1,26 +1,21 @@
 import { IntegrationLogger } from '@jupiterone/integration-sdk-core';
 import { AttemptContext, sleep } from '@lifeomic/attempt';
+import { GraphQlQueryResponse } from '@octokit/graphql/dist-types/types';
+import { GraphqlResponseError } from '@octokit/graphql';
 
-type GraphQLError = {
-  type?: 'NOT_FOUND' | 'FORBIDDEN' | 'RATE_LIMITED' | string;
-  path?: string[];
-  locations?: { line: number; column: number }[];
-  extensions?: {
-    code: string;
-    typeName: string;
-    fieldName: string;
-  };
-  message: string;
-  documentation_url?: string;
-};
-
-const handleTypeErrors = (errors, logger, type: string): boolean => {
-  errors = Array.isArray(errors) ? errors : [errors];
-
+const handleTypeErrors = (
+  errors: GraphQlQueryResponse<never>['errors'],
+  logger,
+  type: string,
+): boolean => {
   if (errors?.every((error) => error.type === type)) {
+    logger.info(
+      { errors, type },
+      'The error was found and ignored because of the type.',
+    );
     errors.forEach((error) => {
       if (error.message) {
-        logger.warn(error.message);
+        logger.debug(error.message);
       }
     });
 
@@ -35,7 +30,7 @@ const handleTypeErrors = (errors, logger, type: string): boolean => {
  * Returns t/f if handled
  */
 export const handleNotFoundErrors = (
-  errors: GraphQLError[] | GraphQLError,
+  errors: GraphQlQueryResponse<never>['errors'],
   logger: IntegrationLogger,
 ): boolean => {
   return handleTypeErrors(errors, logger, 'NOT_FOUND');
@@ -48,7 +43,7 @@ export const handleNotFoundErrors = (
  * @param logger
  */
 export const handleForbiddenErrors = (
-  errors: GraphQLError[] | GraphQLError,
+  errors: GraphQlQueryResponse<never>['errors'],
   logger: IntegrationLogger,
 ): boolean => {
   return handleTypeErrors(errors, logger, 'FORBIDDEN');
@@ -62,12 +57,12 @@ export const handleForbiddenErrors = (
  * @param refreshToken
  */
 export const retryErrorHandle = async (
-  error: GraphQLError[] | GraphQLError,
+  error,
   logger: IntegrationLogger,
   attemptContext: AttemptContext,
   refreshToken: () => Promise<void>,
 ) => {
-  if (Array.isArray(error)) {
+  if (error instanceof GraphqlResponseError) {
     /* GitHub has "Secondary Rate Limits" in case of excessive polling or very costly API calls.
      * GitHub guidance is to "wait a few minutes" when we get one of these errors.
      * https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
@@ -75,11 +70,9 @@ export const retryErrorHandle = async (
      * and our GraphQL client is not using the @octokit throttling and retry plugins like our REST client
      * therefore some retry logic is appropriate here
      */
-    if (error.some((e) => e.type === 'RATE_LIMITED')) {
+    if (error.errors?.some((e) => e.type === 'RATE_LIMITED')) {
       logger.info({ attemptContext, error }, 'Rate limiting message received.');
-    }
-  } else {
-    if (error.message?.includes('Bad credentials')) {
+    } else if (error.message?.includes('Bad credentials')) {
       logger.info({ error }, 'Bad credentials: Refreshing token.');
       await refreshToken();
     } else if (error.message?.includes('exceeded a secondary rate limit')) {

--- a/src/client/GraphQLClient/errorHandlers.ts
+++ b/src/client/GraphQLClient/errorHandlers.ts
@@ -3,6 +3,13 @@ import { AttemptContext, sleep } from '@lifeomic/attempt';
 import { GraphQlQueryResponse } from '@octokit/graphql/dist-types/types';
 import { GraphqlResponseError } from '@octokit/graphql';
 
+/**
+ * If the errors are all the same specified type, ignore them.
+ * @param errors
+ * @param logger
+ * @param type
+ * @return boolean
+ */
 const handleTypeErrors = (
   errors: GraphQlQueryResponse<never>['errors'],
   logger,

--- a/src/client/GraphQLClient/errorHandlers.ts
+++ b/src/client/GraphQLClient/errorHandlers.ts
@@ -8,7 +8,7 @@ const handleTypeErrors = (
   logger,
   type: string,
 ): boolean => {
-  if (errors?.every((error) => error.type === type)) {
+  if (Array.isArray(errors) && errors?.every((error) => error.type === type)) {
     logger.info(
       { errors, type },
       'The error was found and ignored because of the type.',
@@ -70,7 +70,10 @@ export const retryErrorHandle = async (
      * and our GraphQL client is not using the @octokit throttling and retry plugins like our REST client
      * therefore some retry logic is appropriate here
      */
-    if (error.errors?.some((e) => e.type === 'RATE_LIMITED')) {
+    if (
+      Array.isArray(error.errors) &&
+      error.errors?.some((e) => e.type === 'RATE_LIMITED')
+    ) {
       logger.info({ attemptContext, error }, 'Rate limiting message received.');
     } else if (error.message?.includes('Bad credentials')) {
       logger.info({ error }, 'Bad credentials: Refreshing token.');

--- a/src/client/GraphQLClient/utils.test.ts
+++ b/src/client/GraphQLClient/utils.test.ts
@@ -33,4 +33,48 @@ describe('utils', () => {
       }),
     ).toBeTruthy();
   });
+
+  test('responseToResource', () => {
+    expect(
+      utils.responseToResource({
+        id: 'PR_asdf',
+        commits: {
+          totalCount: 11,
+          nodes: [null, null, null, null, null, { commit: { asdf: 'commit' } }],
+          pageInfo: {
+            endCursor: 'MTE',
+            hasNextPage: false,
+          },
+        },
+        reviews: {
+          totalCount: 117,
+          nodes: [
+            null,
+            undefined,
+            {
+              id: 'asdf',
+              commit: null,
+              author: {},
+              state: 'COMMENTED',
+              submittedAt: '2000-04-19T04:33:08Z',
+              updatedAt: '2000-04-19T04:33:08Z',
+              url: 'https://github.com/',
+            },
+          ],
+          pageInfo: {
+            endCursor: 'asdf333',
+            hasNextPage: true,
+          },
+        },
+        labels: {
+          totalCount: 2,
+          nodes: [null, { asdf: 'label' }],
+          pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+          },
+        },
+      }),
+    ).toMatchSnapshot();
+  });
 });

--- a/src/client/GraphQLClient/utils.ts
+++ b/src/client/GraphQLClient/utils.ts
@@ -18,9 +18,11 @@ const responseToResource = (node) => {
 
   return {
     ...node,
-    commits: node.commits?.nodes?.map((node) => node.commit) ?? [],
-    reviews: node.reviews?.nodes ?? [],
-    labels: node.labels?.nodes ?? [],
+    commits:
+      node.commits?.nodes?.filter((node) => node).map((node) => node.commit) ??
+      [],
+    reviews: node.reviews?.nodes?.filter((node) => node) ?? [],
+    labels: node.labels?.nodes?.filter((node) => node) ?? [],
   };
 };
 


### PR DESCRIPTION
The previous graphql client unwrapped the error, only passing error.errors.
The new client returns the entire error. So logic need to be rewired. 
With the entire error, we are also able to return partial data. 

Since errors are hard to manually test, please review the docs [here](https://github.com/octokit/graphql.js/#errors) to see if I missed anything. 