### PR TITLE
Release 1.13.1 and small questions fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 [Unreleased]
 
+## 1.13.1 - 2022-05-05
+
+### Fixed
+
+- `integration-question-github-how-often-are-github-secrets-rotating` 90 days
+  managed question to have `- 90 days`
+
 ### Changed
 
 - Added `code-ql` and `questions` workflow

--- a/jupiterone/questions/questions.yaml
+++ b/jupiterone/questions/questions.yaml
@@ -78,7 +78,7 @@ questions:
     - name: Past 90 Days
       resultsAre: INFORMATIVE
       query: |
-        FIND Secret WITH updatedOn < date.now
+        FIND Secret WITH updatedOn < date.now - 90 days
     - name: Past 180 Days
       resultsAre: INFORMATIVE
       query: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-github",
-  "version": "1.13.1-beta.1",
+  "version": "1.13.1",
   "description": "A JupiterOne Integration",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
Releasing version 1.13.1 for `graph-github` adding managed questions and workflows. Making one small correction to questions made by @BrendanQuinnJ1.