### PR TITLE
fix: remove query fragments from versions that do not support them.

### DIFF
--- a/.github/workflows/peril.yml
+++ b/.github/workflows/peril.yml
@@ -1,9 +1,9 @@
-name: "Peril"
+name: 'Peril'
 
 on:
   pull_request:
 
-env: 
+env:
   TRANSPONDER_DOCKER_IMAGE: 081157560428.dkr.ecr.us-east-1.amazonaws.com/transponder:1
   SECURITY_SCAN_IMAGE: ghcr.io/jupiterone/security-scan:latest
 
@@ -17,74 +17,74 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-        
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-    
-    - name: Run build
-      run: yarn install
-    
-    - name: Get Variables
-      id: get-vars
-      run: |
-        if [[ "${GITHUB_REF}" == 'ref/head/main' && "${GITHUB_EVENT_NAME}" == 'push' ]];
-        then
-          echo ::set-output name=aws-oidc-role::arn:aws:iam::081157560428:role/github-main-role
-        else
-          echo ::set-output name=aws-oidc-role::arn:aws:iam::081157560428:role/github-pull-request-role
-        fi
-    
-    - name: Configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        role-to-assume: ${{ steps.get-vars.outputs.aws-oidc-role }}
-        role-session-name: pr-role-session
-        aws-region: us-east-1
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: ECR login
-      uses: aws-actions/amazon-ecr-login@v1
-      id: amazon-ecr-login
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
-    - name: Login to GHCR
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.PACKAGE_TOKEN }}
+      - name: Run build
+        run: yarn install
 
-    - name: Pull security-scan
-      run: |
-        docker pull $SECURITY_SCAN_IMAGE
-    
-    - name: Run security-scan
-      run: |
-        docker run \
-        --user root \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v `pwd`:`pwd` \
-        -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
-        -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
-        -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
-        -e GITHUB_REPOSITORY=$GITHUB_REPOSITORY \
-        -e GITHUB_REF_NAME=$GITHUB_REF_NAME \
-        -e GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER \
-        -e GITHUB_SERVER_URL=$GITHUB_SERVER_URL \
-        -e GITHUB_RUN_ID=$GITHUB_RUN_ID \
-        -e MODE=ci \
-        -w `pwd` $SECURITY_SCAN_IMAGE
+      - name: Get Variables
+        id: get-vars
+        run: |
+          if [[ "${GITHUB_REF}" == 'ref/head/main' && "${GITHUB_EVENT_NAME}" == 'push' ]];
+          then
+            echo ::set-output name=aws-oidc-role::arn:aws:iam::081157560428:role/github-main-role
+          else
+            echo ::set-output name=aws-oidc-role::arn:aws:iam::081157560428:role/github-pull-request-role
+          fi
 
-    - name: Pull transponder
-      run: |
-        docker pull $TRANSPONDER_DOCKER_IMAGE
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ steps.get-vars.outputs.aws-oidc-role }}
+          role-session-name: pr-role-session
+          aws-region: us-east-1
 
-    - name: Run transponder
-      run: |
-        docker run --rm -v `pwd`:`pwd` -w `pwd` \
-        -e J1_API_KEY=${{ secrets.J1_API_KEY_TRANSPONDER }} \
-        -e J1_API_DOMAIN=${{ secrets.J1_API_DOMAIN_TRANSPONDER }} \
-        -e J1_ACCOUNT_ID=${{ secrets.J1_ACCOUNT_ID_TRANSPONDER }} \
-        $TRANSPONDER_DOCKER_IMAGE
+      - name: ECR login
+        uses: aws-actions/amazon-ecr-login@v1
+        id: amazon-ecr-login
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PACKAGE_TOKEN }}
+
+      - name: Pull security-scan
+        run: |
+          docker pull $SECURITY_SCAN_IMAGE
+
+      - name: Run security-scan
+        run: |
+          docker run \
+          --user root \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -v `pwd`:`pwd` \
+          -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
+          -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
+          -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
+          -e GITHUB_REPOSITORY=$GITHUB_REPOSITORY \
+          -e GITHUB_REF_NAME=$GITHUB_REF_NAME \
+          -e GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER \
+          -e GITHUB_SERVER_URL=$GITHUB_SERVER_URL \
+          -e GITHUB_RUN_ID=$GITHUB_RUN_ID \
+          -e MODE=ci \
+          -w `pwd` $SECURITY_SCAN_IMAGE
+
+      - name: Pull transponder
+        run: |
+          docker pull $TRANSPONDER_DOCKER_IMAGE
+
+      - name: Run transponder
+        run: |
+          docker run --rm -v `pwd`:`pwd` -w `pwd` \
+          -e J1_API_KEY=${{ secrets.J1_API_KEY_TRANSPONDER }} \
+          -e J1_API_DOMAIN=${{ secrets.J1_API_DOMAIN_TRANSPONDER }} \
+          -e J1_ACCOUNT_ID=${{ secrets.J1_ACCOUNT_ID_TRANSPONDER }} \
+          $TRANSPONDER_DOCKER_IMAGE

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@jupiterone/integration-sdk-dev-tools": "^8.18.0",
     "@jupiterone/integration-sdk-testing": "^8.18.0",
     "@types/lodash.omit": "^4.5.6",
+    "@types/semver": "^7.3.13",
     "auto": "^10.36.5"
   },
   "auto": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -341,6 +341,7 @@ export class APIClient {
         await this.graphQLClient.iterateRepoBranchProtectionRules(
           repoName,
           iteratee,
+          this.gheServerVersion,
         );
 
       this.logger.debug(

--- a/src/client/GraphQLClient/branchProtectionRulesQueries/BranchProtectionRulesQuery.test.ts
+++ b/src/client/GraphQLClient/branchProtectionRulesQueries/BranchProtectionRulesQuery.test.ts
@@ -4,29 +4,35 @@ import { branchProtectionRulesResponses } from './testResponses';
 describe('BranchProtectionRulesQuery', () => {
   describe('#iterateBranchProtectionRules', () => {
     test('Pulling data out', async () => {
-      const iteratee = jest.fn();
-      const execute = jest
-        .fn()
-        .mockResolvedValueOnce(branchProtectionRulesResponses[0]);
+      const mockGheVersions = ['3.4.0', '3.5.0', '3.6.0'];
 
-      // Act
-      const result =
-        await BranchProtectionRulesQuery.iterateBranchProtectionRules(
-          {
-            repoOwner: 'J1-Test',
-            repoName: 'happy-sunshine',
-          },
-          execute,
-          iteratee,
-        );
+      for (const version of mockGheVersions) {
+        const execute = jest
+          .fn()
+          .mockResolvedValue(branchProtectionRulesResponses[0]);
 
-      // Assert
-      expect(result.totalCost).toBe(0);
-      expect(iteratee).toHaveBeenCalledTimes(2);
-      expect(iteratee.mock.calls[0][0]).toMatchSnapshot();
-      expect(iteratee.mock.calls[1][0]).toMatchSnapshot();
-      expect(execute).toHaveBeenCalledTimes(1);
-      expect(execute.mock.calls[0][0]).toMatchSnapshot();
+        const iteratee = jest.fn();
+
+        // Act
+        const result =
+          await BranchProtectionRulesQuery.iterateBranchProtectionRules(
+            {
+              repoOwner: 'J1-Test',
+              repoName: 'happy-sunshine',
+              gheServerVersion: version,
+            },
+            execute,
+            iteratee,
+          );
+
+        // Assert
+        expect(result.totalCost).toBe(0);
+        expect(iteratee).toHaveBeenCalledTimes(2);
+        expect(iteratee.mock.calls[0][0]).toMatchSnapshot();
+        expect(iteratee.mock.calls[1][0]).toMatchSnapshot();
+        expect(execute).toHaveBeenCalledTimes(1);
+        expect(execute.mock.calls[0][0]).toMatchSnapshot();
+      }
     });
   });
 });

--- a/src/client/GraphQLClient/branchProtectionRulesQueries/__snapshots__/BranchProtectionRulesQuery.test.ts.snap
+++ b/src/client/GraphQLClient/branchProtectionRulesQueries/__snapshots__/BranchProtectionRulesQuery.test.ts.snap
@@ -144,7 +144,6 @@ Object {
                 isAdminEnforced
                 allowsForcePushes
                 allowsDeletions
-                blocksCreations
                 requiresConversationResolution
                 pattern
                 allowsDeletions
@@ -166,93 +165,617 @@ Object {
                   }
                 }
                 bypassForcePushAllowances(first: $maxLimit) {
-                  nodes {
-                    
-    actor {
-      __typename
-      ... on App {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    
+  }
+        }
+      }
+      bypassPullRequestAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    
+  }
+        }
+      }
+      pushAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    ... on App {
         id
         name
         databaseId
       }
-      ... on Team {
-        id
-        name
+  }
+        }
       }
-      ... on User {
-        id
-        login
-        email
-      }
+      reviewDismissalAllowances(first: $maxLimit)
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
     }
+    ... on User {
+      id
+      login
+      email
+    }
+    
+  }
+        }
+      }
+              }
+            }
+          }
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
+      }
+  ",
+  "queryVariables": Object {
+    "maxLimit": 100,
+    "repoName": "happy-sunshine",
+    "repoOwner": "J1-Test",
+  },
+}
+`;
+
+exports[`BranchProtectionRulesQuery #iterateBranchProtectionRules Pulling data out 4`] = `
+Object {
+  "allowsDeletions": false,
+  "allowsForcePushes": false,
+  "blocksCreations": false,
+  "bypassForcePushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "bypassPullRequestAllowances": Object {
+    "apps": Array [],
+    "teams": Array [
+      Object {
+        "__typename": "Team",
+        "id": "T_kwDOBfl5Zc4AWFta",
+        "name": "j1-nested-team",
+      },
+    ],
+    "users": Array [
+      Object {
+        "__typename": "User",
+        "email": "",
+        "id": "MDQ6VXNlcjU1NzcxODIz",
+        "login": "adam-in-ict",
+      },
+    ],
+  },
+  "creator": Object {
+    "login": "VDubber",
+  },
+  "databaseId": 25221868,
+  "dismissesStaleReviews": false,
+  "id": "BPR_sdflk_slkwefoi",
+  "isAdminEnforced": false,
+  "pattern": "release-*",
+  "pushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "repoName": "reimagined-barnacle",
+  "requiredApprovingReviewCount": 2,
+  "requiredStatusCheckContexts": Array [],
+  "requiredStatusChecks": Array [],
+  "requiresApprovingReviews": true,
+  "requiresCodeOwnerReviews": false,
+  "requiresCommitSignatures": true,
+  "requiresConversationResolution": false,
+  "requiresLinearHistory": false,
+  "requiresStatusChecks": false,
+  "requiresStrictStatusChecks": true,
+  "restrictsPushes": false,
+  "restrictsReviewDismissals": false,
+  "reviewDismissalAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+}
+`;
+
+exports[`BranchProtectionRulesQuery #iterateBranchProtectionRules Pulling data out 5`] = `
+Object {
+  "allowsDeletions": false,
+  "allowsForcePushes": false,
+  "blocksCreations": false,
+  "bypassForcePushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "bypassPullRequestAllowances": Object {
+    "apps": Array [],
+    "teams": Array [
+      Object {
+        "__typename": "Team",
+        "id": "T_kwDOBfl5Zc4AWFta",
+        "name": "j1-nested-team",
+      },
+    ],
+    "users": Array [
+      Object {
+        "__typename": "User",
+        "email": "",
+        "id": "MDQ6VXNlcjE2NTYyMDg1",
+        "login": "electricgull",
+      },
+    ],
+  },
+  "creator": Object {
+    "login": "electricgull",
+  },
+  "databaseId": 27924631,
+  "dismissesStaleReviews": true,
+  "isAdminEnforced": true,
+  "pattern": "main",
+  "pushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "repoName": "reimagined-barnacle",
+  "requiredApprovingReviewCount": 1,
+  "requiredStatusCheckContexts": Array [],
+  "requiredStatusChecks": Array [],
+  "requiresApprovingReviews": true,
+  "requiresCodeOwnerReviews": false,
+  "requiresCommitSignatures": false,
+  "requiresConversationResolution": false,
+  "requiresLinearHistory": false,
+  "requiresStatusChecks": true,
+  "requiresStrictStatusChecks": false,
+  "restrictsPushes": false,
+  "restrictsReviewDismissals": false,
+  "reviewDismissalAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+}
+`;
+
+exports[`BranchProtectionRulesQuery #iterateBranchProtectionRules Pulling data out 6`] = `
+Object {
+  "query": "
+      query (
+        $repoName: String!
+        $repoOwner: String!
+        $maxLimit: Int!
+      ) {
+          repository(name: $repoName, owner: $repoOwner) {
+            name
+            branchProtectionRules(first: $maxLimit) {
+              nodes {
+                id
+                requiresLinearHistory
+                requiredApprovingReviewCount
+                dismissesStaleReviews
+                requiresCodeOwnerReviews
+                requiresCommitSignatures
+                isAdminEnforced
+                allowsForcePushes
+                allowsDeletions
+                requiresConversationResolution
+                pattern
+                allowsDeletions
+                requiresApprovingReviews
+                requiredStatusCheckContexts
+                creator {
+                  login
+                }
+                databaseId
+                requiresStatusChecks
+                requiresStrictStatusChecks
+                restrictsPushes
+                restrictsReviewDismissals
+                requiredStatusChecks {
+                  context
+                  app {
+                    id
+                    name
                   }
                 }
-                bypassPullRequestAllowances(first: $maxLimit) {
-                  nodes {
-                    
-    actor {
-      __typename
-      ... on App {
+                blocksCreations
+bypassForcePushAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    
+  }
+        }
+      }
+      bypassPullRequestAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    
+  }
+        }
+      }
+      pushAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    ... on App {
         id
         name
         databaseId
       }
-      ... on Team {
-        id
-        name
+  }
+        }
       }
-      ... on User {
-        id
-        login
-        email
-      }
+      reviewDismissalAllowances(first: $maxLimit)
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
     }
+    ... on User {
+      id
+      login
+      email
+    }
+    
+  }
+        }
+      }
+              }
+            }
+          }
+          ...on Query {
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }
+      }
+  ",
+  "queryVariables": Object {
+    "maxLimit": 100,
+    "repoName": "happy-sunshine",
+    "repoOwner": "J1-Test",
+  },
+}
+`;
+
+exports[`BranchProtectionRulesQuery #iterateBranchProtectionRules Pulling data out 7`] = `
+Object {
+  "allowsDeletions": false,
+  "allowsForcePushes": false,
+  "blocksCreations": false,
+  "bypassForcePushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "bypassPullRequestAllowances": Object {
+    "apps": Array [],
+    "teams": Array [
+      Object {
+        "__typename": "Team",
+        "id": "T_kwDOBfl5Zc4AWFta",
+        "name": "j1-nested-team",
+      },
+    ],
+    "users": Array [
+      Object {
+        "__typename": "User",
+        "email": "",
+        "id": "MDQ6VXNlcjU1NzcxODIz",
+        "login": "adam-in-ict",
+      },
+    ],
+  },
+  "creator": Object {
+    "login": "VDubber",
+  },
+  "databaseId": 25221868,
+  "dismissesStaleReviews": false,
+  "id": "BPR_sdflk_slkwefoi",
+  "isAdminEnforced": false,
+  "pattern": "release-*",
+  "pushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "repoName": "reimagined-barnacle",
+  "requiredApprovingReviewCount": 2,
+  "requiredStatusCheckContexts": Array [],
+  "requiredStatusChecks": Array [],
+  "requiresApprovingReviews": true,
+  "requiresCodeOwnerReviews": false,
+  "requiresCommitSignatures": true,
+  "requiresConversationResolution": false,
+  "requiresLinearHistory": false,
+  "requiresStatusChecks": false,
+  "requiresStrictStatusChecks": true,
+  "restrictsPushes": false,
+  "restrictsReviewDismissals": false,
+  "reviewDismissalAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+}
+`;
+
+exports[`BranchProtectionRulesQuery #iterateBranchProtectionRules Pulling data out 8`] = `
+Object {
+  "allowsDeletions": false,
+  "allowsForcePushes": false,
+  "blocksCreations": false,
+  "bypassForcePushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "bypassPullRequestAllowances": Object {
+    "apps": Array [],
+    "teams": Array [
+      Object {
+        "__typename": "Team",
+        "id": "T_kwDOBfl5Zc4AWFta",
+        "name": "j1-nested-team",
+      },
+    ],
+    "users": Array [
+      Object {
+        "__typename": "User",
+        "email": "",
+        "id": "MDQ6VXNlcjE2NTYyMDg1",
+        "login": "electricgull",
+      },
+    ],
+  },
+  "creator": Object {
+    "login": "electricgull",
+  },
+  "databaseId": 27924631,
+  "dismissesStaleReviews": true,
+  "isAdminEnforced": true,
+  "pattern": "main",
+  "pushAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+  "repoName": "reimagined-barnacle",
+  "requiredApprovingReviewCount": 1,
+  "requiredStatusCheckContexts": Array [],
+  "requiredStatusChecks": Array [],
+  "requiresApprovingReviews": true,
+  "requiresCodeOwnerReviews": false,
+  "requiresCommitSignatures": false,
+  "requiresConversationResolution": false,
+  "requiresLinearHistory": false,
+  "requiresStatusChecks": true,
+  "requiresStrictStatusChecks": false,
+  "restrictsPushes": false,
+  "restrictsReviewDismissals": false,
+  "reviewDismissalAllowances": Object {
+    "apps": Array [],
+    "teams": Array [],
+    "users": Array [],
+  },
+}
+`;
+
+exports[`BranchProtectionRulesQuery #iterateBranchProtectionRules Pulling data out 9`] = `
+Object {
+  "query": "
+      query (
+        $repoName: String!
+        $repoOwner: String!
+        $maxLimit: Int!
+      ) {
+          repository(name: $repoName, owner: $repoOwner) {
+            name
+            branchProtectionRules(first: $maxLimit) {
+              nodes {
+                id
+                requiresLinearHistory
+                requiredApprovingReviewCount
+                dismissesStaleReviews
+                requiresCodeOwnerReviews
+                requiresCommitSignatures
+                isAdminEnforced
+                allowsForcePushes
+                allowsDeletions
+                requiresConversationResolution
+                pattern
+                allowsDeletions
+                requiresApprovingReviews
+                requiredStatusCheckContexts
+                creator {
+                  login
+                }
+                databaseId
+                requiresStatusChecks
+                requiresStrictStatusChecks
+                restrictsPushes
+                restrictsReviewDismissals
+                requiredStatusChecks {
+                  context
+                  app {
+                    id
+                    name
                   }
                 }
-                pushAllowances(first: $maxLimit) {
-                  nodes {
-                    
-    actor {
-      __typename
-      ... on App {
+                blocksCreations
+bypassForcePushAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    ... on App {
         id
         name
         databaseId
       }
-      ... on Team {
-        id
-        name
+  }
+        }
       }
-      ... on User {
-        id
-        login
-        email
-      }
+      bypassPullRequestAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
     }
-                  }
-                }
-                reviewDismissalAllowances(first: $maxLimit) {
-                  nodes {
-                    
-    actor {
-      __typename
-      ... on App {
+    ... on User {
+      id
+      login
+      email
+    }
+    ... on App {
         id
         name
         databaseId
       }
-      ... on Team {
+  }
+        }
+      }
+      pushAllowances(first: $maxLimit) {
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
+    }
+    ... on User {
+      id
+      login
+      email
+    }
+    ... on App {
         id
         name
+        databaseId
       }
-      ... on User {
-        id
-        login
-        email
+  }
+        }
       }
+      reviewDismissalAllowances(first: $maxLimit)
+        nodes {
+          
+  actor {
+    __typename
+    ... on Team {
+      id
+      name
     }
-                  }
-                }
+    ... on User {
+      id
+      login
+      email
+    }
+    ... on App {
+        id
+        name
+        databaseId
+      }
+  }
+        }
+      }
               }
             }
           }

--- a/src/client/GraphQLClient/client.ts
+++ b/src/client/GraphQLClient/client.ts
@@ -395,6 +395,7 @@ export class GitHubGraphQLClient {
   public async iterateRepoBranchProtectionRules(
     login: string,
     repoName: string,
+    gheServerVersion: string | undefined,
     iteratee: ResourceIteratee<BranchProtectionRuleResponse>,
   ): Promise<RateLimitStepSummary> {
     const executor = createQueryExecutor(this, this.logger);

--- a/src/client/GraphQLClient/utils.ts
+++ b/src/client/GraphQLClient/utils.ts
@@ -76,6 +76,8 @@ const hasProperties = (object: any) => {
 export enum EnterpriseFeatures {
   REPO_VULN_ALERT_STATE_ARG = '3.5.0',
   REPO_VULN_ALERT_FIELDS = '3.5.0', // fixReason, fixedAt, number, state were added
+  BRANCH_PROTECTION_RULES_BLOCKS_CREATIONS_FIELD = '3.5.0',
+  BRANCH_PROTECTION_RULES_APP_MEMBER = '3.6.0',
 }
 
 /**

--- a/src/client/OrganizationAccountClient.ts
+++ b/src/client/OrganizationAccountClient.ts
@@ -266,10 +266,12 @@ export default class OrganizationAccountClient {
   async iterateRepoBranchProtectionRules(
     repoName: string,
     iteratee: ResourceIteratee<BranchProtectionRuleResponse>,
+    gheServerVersion?: string,
   ): Promise<RateLimitStepSummary> {
     return await this.v4.iterateRepoBranchProtectionRules(
       this.login,
       repoName,
+      gheServerVersion,
       iteratee,
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
   integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
 
+"@types/semver@^7.3.13":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@types/set-cookie-parser@^2.4.1":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz#b6a955219b54151bfebd4521170723df5e13caad"


### PR DESCRIPTION
From Github GraphQL API changelog:
In version 3.6.0
- Member `App` was added to Union type BranchActorAllowanceActor (used in `bypassForcePushAllowances` and `bypassPullRequestAllowances`)
- Member `App` was added to Union type ReviewDismissalAllowanceActor(used in `reviewDismissalAllowances`)

In version 3.5.0
- Field `blocksCreations` was added to object type `BranchProtectionRule`

This PR removes those fields from the query for versions below these.

Note: `pushAllowances` has members `App`, `Team` and `User` in all versions