### PR TITLE
Disable code scanning for ghe <3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.3 - 2023-03-06
+
+### Changed
+
+- Code Scanning alert step will now self-disabled if the GHE version (<3.5.0)
+  does not support Organization level code scanning alerts ingestion.
+
 ## 2.0.2 - 2023-02-23
 
 ### Changed

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,7 +7,7 @@ import {
   parseTimePropertyValue,
 } from '@jupiterone/integration-sdk-core';
 
-import { IntegrationConfig } from './config';
+import { IntegrationConfig, Scopes } from './config';
 import {
   AccountType,
   EnvironmentEntity,
@@ -61,18 +61,7 @@ export class APIClient {
   restClient: Octokit;
   ghsToken: string;
   gheServerVersion?: string;
-  scopes: {
-    orgAdmin: boolean;
-    orgSecrets: boolean;
-    repoAdmin: boolean;
-    codeScanningAlerts: boolean;
-    repoSecrets: boolean;
-    repoEnvironments: boolean;
-    repoIssues: boolean;
-    dependabotAlerts: boolean;
-    repoPages: boolean;
-    repoDiscussions: boolean;
-  };
+  scopes: Scopes;
 
   readonly restApiUrl: string;
   readonly graphqlUrl: string;

--- a/src/client/GraphQLClient/utils.ts
+++ b/src/client/GraphQLClient/utils.ts
@@ -78,6 +78,10 @@ export enum EnterpriseFeatures {
   REPO_VULN_ALERT_FIELDS = '3.5.0', // fixReason, fixedAt, number, state were added
   BRANCH_PROTECTION_RULES_BLOCKS_CREATIONS_FIELD = '3.5.0',
   BRANCH_PROTECTION_RULES_APP_MEMBER = '3.6.0',
+  /**
+   * Docs link: https://docs.github.com/en/enterprise-server@3.5/rest/code-scanning#list-code-scanning-alerts-for-an-organization
+   */
+  LIST_CODE_SCANNING_ALERT_FOR_ORG = '3.5.0',
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,18 +110,24 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
   dependabotAlertSeverities: string[];
 }
 
-export async function validateInvocation(
-  context: IntegrationExecutionContext<IntegrationConfig>,
-): Promise<{
+export type Scopes = {
   codeScanningAlerts: boolean;
   orgAdmin: boolean;
   orgSecrets: boolean;
   repoAdmin: boolean;
   repoSecrets: boolean;
+  repoPages: boolean;
   repoEnvironments: boolean;
   repoIssues: boolean;
   dependabotAlerts: boolean;
   repoDiscussions: boolean;
+};
+
+export async function validateInvocation(
+  context: IntegrationExecutionContext<IntegrationConfig>,
+): Promise<{
+  scopes: Scopes;
+  gheServerVersion?: string;
 }> {
   const { config } = context.instance;
 
@@ -129,7 +135,11 @@ export async function validateInvocation(
 
   const apiClient = getOrCreateApiClient(config, context.logger);
   await apiClient.verifyAuthentication();
-  return apiClient.scopes;
+
+  return {
+    scopes: apiClient.scopes,
+    gheServerVersion: apiClient.gheServerVersion,
+  };
 }
 
 /**

--- a/src/getStepStartStates.test.ts
+++ b/src/getStepStartStates.test.ts
@@ -8,15 +8,18 @@ describe('getStepStartStates', () => {
     const validateInvocationSpy = jest
       .spyOn(config, 'validateInvocation')
       .mockResolvedValueOnce({
-        repoAdmin: true,
-        repoIssues: true,
-        orgAdmin: true,
-        repoEnvironments: true,
-        orgSecrets: false,
-        repoSecrets: false,
-        dependabotAlerts: true,
-        repoDiscussions: true,
-        codeScanningAlerts: false,
+        scopes: {
+          repoAdmin: true,
+          repoIssues: true,
+          orgAdmin: true,
+          repoEnvironments: true,
+          orgSecrets: false,
+          repoSecrets: false,
+          repoPages: false,
+          dependabotAlerts: true,
+          repoDiscussions: true,
+          codeScanningAlerts: false,
+        },
       });
     const context = {
       instance: {
@@ -37,15 +40,18 @@ describe('getStepStartStates', () => {
     const validateInvocationSpy = jest
       .spyOn(config, 'validateInvocation')
       .mockResolvedValueOnce({
-        repoAdmin: true,
-        repoIssues: true,
-        orgAdmin: true,
-        repoEnvironments: true,
-        orgSecrets: false,
-        repoSecrets: false,
-        dependabotAlerts: true,
-        repoDiscussions: true,
-        codeScanningAlerts: false,
+        scopes: {
+          repoAdmin: true,
+          repoIssues: true,
+          orgAdmin: true,
+          repoEnvironments: true,
+          orgSecrets: false,
+          repoPages: false,
+          repoSecrets: false,
+          dependabotAlerts: true,
+          repoDiscussions: true,
+          codeScanningAlerts: false,
+        },
       });
 
     const context = {
@@ -67,15 +73,18 @@ describe('getStepStartStates', () => {
     const validateInvocationSpy = jest
       .spyOn(config, 'validateInvocation')
       .mockResolvedValueOnce({
-        repoAdmin: true,
-        repoIssues: true,
-        repoEnvironments: true,
-        orgAdmin: true,
-        orgSecrets: false,
-        repoSecrets: false,
-        dependabotAlerts: false,
-        repoDiscussions: true,
-        codeScanningAlerts: false,
+        scopes: {
+          repoAdmin: true,
+          repoIssues: true,
+          repoEnvironments: true,
+          orgAdmin: true,
+          orgSecrets: false,
+          repoSecrets: false,
+          repoPages: false,
+          dependabotAlerts: false,
+          repoDiscussions: true,
+          codeScanningAlerts: false,
+        },
       });
 
     const context = {
@@ -97,43 +106,52 @@ describe('getStepStartStates', () => {
     const validateInvocationSpy = jest
       .spyOn(config, 'validateInvocation')
       .mockResolvedValueOnce({
-        // tested permissions
-        repoAdmin: true,
-        repoDiscussions: true,
-        // not applicable
-        repoIssues: true,
-        repoEnvironments: true,
-        orgAdmin: true,
-        orgSecrets: false,
-        repoSecrets: false,
-        dependabotAlerts: false,
-        codeScanningAlerts: false,
+        scopes: {
+          // tested permissions
+          repoAdmin: true,
+          repoDiscussions: true,
+          // not applicable
+          repoIssues: true,
+          repoEnvironments: true,
+          orgAdmin: true,
+          repoPages: true,
+          orgSecrets: false,
+          repoSecrets: false,
+          dependabotAlerts: false,
+          codeScanningAlerts: false,
+        },
       })
       .mockResolvedValueOnce({
-        // tested permissions
-        repoAdmin: true,
-        repoDiscussions: false,
-        // not applicable
-        repoIssues: true,
-        repoEnvironments: true,
-        orgAdmin: true,
-        orgSecrets: false,
-        repoSecrets: false,
-        dependabotAlerts: false,
-        codeScanningAlerts: false,
+        scopes: {
+          // tested permissions
+          repoAdmin: true,
+          repoDiscussions: false,
+          // not applicable
+          repoIssues: true,
+          repoEnvironments: true,
+          orgAdmin: true,
+          repoPages: false,
+          orgSecrets: true,
+          repoSecrets: false,
+          dependabotAlerts: false,
+          codeScanningAlerts: false,
+        },
       })
       .mockResolvedValueOnce({
-        // tested permissions
-        repoAdmin: false,
-        repoDiscussions: false,
-        // not applicable
-        repoIssues: true,
-        repoEnvironments: true,
-        orgAdmin: true,
-        orgSecrets: false,
-        repoSecrets: false,
-        dependabotAlerts: false,
-        codeScanningAlerts: false,
+        scopes: {
+          // tested permissions
+          repoAdmin: false,
+          repoDiscussions: false,
+          // not applicable
+          repoIssues: true,
+          repoEnvironments: true,
+          orgAdmin: true,
+          repoPages: false,
+          orgSecrets: false,
+          repoSecrets: false,
+          dependabotAlerts: false,
+          codeScanningAlerts: false,
+        },
       });
 
     const states = await getStepStartStates({
@@ -152,5 +170,56 @@ describe('getStepStartStates', () => {
       instance: { config: {} },
     } as any);
     expect(states3['fetch-branch-protection-rules'].disabled).toBeTruthy();
+  });
+
+  test('enable fetch-code-scanning-alerts', async () => {
+    const validateInvocationSpy = jest
+      .spyOn(config, 'validateInvocation')
+      .mockResolvedValueOnce({
+        scopes: {
+          // tested permissions
+          repoAdmin: true,
+          repoDiscussions: true,
+          // not applicable
+          repoIssues: true,
+          repoEnvironments: true,
+          repoPages: false,
+          orgAdmin: true,
+          orgSecrets: false,
+          repoSecrets: false,
+          dependabotAlerts: false,
+          codeScanningAlerts: true,
+        },
+        gheServerVersion: '5.0.0',
+      })
+      .mockResolvedValueOnce({
+        scopes: {
+          // tested permissions
+          repoAdmin: true,
+          repoDiscussions: true,
+          // not applicable
+          repoIssues: true,
+          repoEnvironments: true,
+          repoPages: false,
+          orgAdmin: true,
+          orgSecrets: false,
+          repoSecrets: false,
+          dependabotAlerts: false,
+          codeScanningAlerts: true,
+        },
+        gheServerVersion: '1.0.0',
+      });
+
+    const states = await getStepStartStates({
+      instance: { config: {} },
+    } as any);
+
+    expect(validateInvocationSpy).toHaveBeenCalled();
+    expect(states['fetch-code-scanning-alerts'].disabled).toBeFalsy();
+
+    const states2 = await getStepStartStates({
+      instance: { config: {} },
+    } as any);
+    expect(states2['fetch-code-scanning-alerts'].disabled).toBeTruthy();
   });
 });

--- a/src/steps/pullRequests.test.ts
+++ b/src/steps/pullRequests.test.ts
@@ -43,7 +43,6 @@ test('fetchPrs exec handler', async () => {
     collectedRelationships: collectedRelationships,
     encounteredTypes: encounteredTypes,
   }).toMatchSnapshot();
-  //  JUPITERONE_API_KEY=6a871d80f5054806bf0f114f075dac43e1079b41e1348baa5931363736303536333730333334 JUPITERONE_ACCOUNT=j1dev  j1-integration run --integrationInstanceId 1483f1e2-d6a7-466b-8a3a-1d6dd97f4373 --api-base-url https://api.dev.jupiterone.io -d  --api-key 6a871d80f5054806bf0f114f075dac43e1079b41e1348baa5931363736303536333730333334
   const issues = collectedEntities.filter(
     (e) => e._type === GithubEntities.GITHUB_PR._type,
   );


### PR DESCRIPTION
If a customer is using a version of GHE that doesn't support org level code scanning requests, disable it.